### PR TITLE
Make pip release, tweak search request

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include release_notes.txt
-include requirements.txt
+include setup_requirements.txt
 include unrar/*
 recursive-include scripts *.py *.txt
 recursive-include desktop-integration *

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ pydist:
 	make clean
 	mkdir -p piprelease
 	rm -f comictagger-$(VERSION_STR).zip
-	python setup.py sdist --formats=zip  #,gztar
+	python3 setup.py sdist --formats=zip  #,gztar
 	mv dist/comictagger-$(VERSION_STR).zip piprelease
 	rm -rf comictagger.egg-info dist
 		

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,0 +1,38 @@
+Metadata-Version: 1.1
+Name: comictagger
+Version: 1.1.32rc1
+Summary: A cross-platform GUI/CLI app for writing metadata to comic archives
+Home-page: https://github.com/davide-romanini/comictagger
+Author: ComicTagger team
+Author-email: comictagger@gmail.com
+License: Apache License 2.0
+Description: 
+        ComicTagger is a multi-platform app for writing metadata to digital comics, written in Python and PyQt.
+        
+        Features:
+        
+        * Runs on Mac OSX, Microsoft Windows, and Linux systems
+        * Communicates with an online database (Comic Vine) for acquiring metadata
+        * Uses image processing to automatically match a given archive with the correct issue data
+        * Batch processing in the GUI for tagging hundreds or more comics at a time
+        * Reads and writes multiple tagging schemes ( ComicBookLover and ComicRack).
+        * Reads and writes RAR and Zip archives (external tools needed for writing RAR)
+        * Command line interface (CLI) on all platforms (including Windows), which supports batch operations, and which can be used in native scripts for complex operations.
+        * Can run without PyQt5 installed 
+        
+Keywords: comictagger,comics,comic,metadata,tagging,tagger
+Platform: UNKNOWN
+Classifier: Development Status :: 4 - Beta
+Classifier: Environment :: Console
+Classifier: Environment :: Win32 (MS Windows)
+Classifier: Environment :: MacOS X
+Classifier: Environment :: X11 Applications :: Qt
+Classifier: Intended Audience :: End Users/Desktop
+Classifier: License :: OSI Approved :: Apache Software License
+Classifier: Natural Language :: English
+Classifier: Operating System :: OS Independent
+Classifier: Programming Language :: Python :: 3.5
+Classifier: Programming Language :: Python :: 3.6
+Classifier: Topic :: Utilities
+Classifier: Topic :: Other/Nonlisted Topic
+Classifier: Topic :: Multimedia :: Graphics

--- a/comictaggerlib/comicvinetalker.py
+++ b/comictaggerlib/comicvinetalker.py
@@ -235,7 +235,7 @@ class ComicVineTalker(QObject):
 
         search_url = self.api_base_url + "/search/?api_key=" + self.api_key + "&format=json&resources=volume&query=" + \
             query_string + \
-            "&field_list=name,id,start_year,publisher,image,description,count_of_issues"
+            "&field_list=name,id,start_year,publisher,image,description,count_of_issues&limit=100"
         cv_response = self.getCVContent(search_url + "&page=1")
 
         search_results = list()

--- a/comictaggerlib/ctversion.py
+++ b/comictaggerlib/ctversion.py
@@ -1,3 +1,3 @@
 # This file should contain only these comments, and the line below.
 # Used by packaging makefiles and app
-version = "1.1.32-rc1"
+version = "1.1.32rc1"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ import comictaggerlib.ctversion
 python_requires='>=3',
 
 
-with open('requirements.txt') as f:
+with open('setup_requirements.txt') as f:
     required = f.read().splitlines()
 # Always require PyQt5 on Windows and Mac
 if platform.system() in [ "Windows", "Darwin" ]:
@@ -198,7 +198,7 @@ setup(name="comictagger",
       author="ComicTagger team",
       author_email="comictagger@gmail.com",
       url="https://github.com/davide-romanini/comictagger",
-      download_url="https://pypi.python.org/packages/source/c/comictagger/comictagger-{0}.zip".format(comictaggerlib.ctversion.version),
+      #download_url="https://pypi.python.org/packages/source/c/comictagger/comictagger-{0}.zip".format(comictaggerlib.ctversion.version),
       packages=["comictaggerlib", "comicapi"],
       package_data={
           'comictaggerlib': ['ui/*', 'graphics/*', '*.so'],

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,0 +1,6 @@
+configparser
+beautifulsoup4 >= 4.1
+unrar==0.3
+natsort==3.5.2
+PyPDF2==1.24
+pillow>=4.3.0


### PR DESCRIPTION
Sorry, two things at once, I'm not great with github.

1.  Main thing is fixing the ability to create pip-able zip files.  By running "make pydist", a zip file will be created in "piprelease" subfolder.  This can be used with pip3.  i.e.:
`pip3 install comictagger-1.1.32rc1.zip`
 It can also be uploaded to pypi.org
Note:  The format of the version string had to be changed to remove the '-' to conform to PEP440.

2.  Changed the Comic Vine search request URL to ask for a maximum of 100 items at once, instead of the default of 10.  This should result in less Comic Vine hits.