### PR TITLE
Enable PyInstaller console flag

### DIFF
--- a/comictagger.spec
+++ b/comictagger.spec
@@ -41,7 +41,7 @@ exe = EXE(pyz,
           debug=False,
           strip=False,
           upx=True,
-          console=False,
+          console=True,
           icon="windows/app.ico" )
 
 app = BUNDLE(exe,


### PR DESCRIPTION
Should enable CLI also under powershell.

Fix #127 