### PR TITLE
Allow for macOS dark mode

### DIFF
--- a/comictagger.spec
+++ b/comictagger.spec
@@ -49,6 +49,7 @@ app = BUNDLE(exe,
             icon='mac/app.icns',
             info_plist={
                 'NSHighResolutionCapable': 'True',
+                'NSRequiresAquaSystemAppearance': 'False',
                 'CFBundleDisplayName': 'ComicTagger',
                 'CFBundleShortVersionString': ctversion.version,
                 'CFBundleVersion': ctversion.version

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ unrar==0.3
 natsort==3.5.2
 PyPDF2==1.24
 pillow>=4.3.0
-PyQt5>=5.10.1
+PyQt5>=5.12.2
 pyinstaller>=3.5


### PR DESCRIPTION
 * ensure we use a more recent PyQt5 version
 * set the `NSRequiresAquaSystemAppearance` is `False` as explained [here](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app)

![Screen Shot 2019-10-05 at 10 37 10 PM](https://user-images.githubusercontent.com/731199/66261243-9f5eb800-e7c1-11e9-8e03-f6d7677ab4a8.png)

Maybe fix #128 