### PR TITLE
Better console handling on Windows

### DIFF
--- a/comictagger.spec
+++ b/comictagger.spec
@@ -4,6 +4,7 @@ import platform
 from os.path import join
 from comictaggerlib import ctversion
 
+enable_console = False
 binaries = []
 block_cipher = None
 
@@ -15,6 +16,7 @@ if platform.system() == "Windows":
         (join(sitepackages, "PyQt5/Qt/bin/libeay32.dll"), "./PyQt5/Qt/bin"),
         (join(sitepackages, "PyQt5/Qt/bin/ssleay32.dll"), "./PyQt5/Qt/bin")
     ])
+    enable_console = True
 
 a = Analysis(['comictagger.py'],
              binaries=binaries,
@@ -39,7 +41,7 @@ exe = EXE(pyz,
           debug=False,
           strip=False,
           upx=True,
-          console=True,
+          console=enable_console,
           icon="windows/app.ico" )
 
 app = BUNDLE(exe,

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -61,14 +61,7 @@ def ctmain():
     if opts.no_gui:
         cli.cli_mode(opts, SETTINGS)
     else:
-        
-        os.environ['QT_AUTO_SCREEN_SCALE_FACTOR'] = '1'
-        
-        #if platform.system() == "Darwin":
-        #    QtWidgets.QApplication.setStyle("macintosh")
-        #else:
-        #    QtWidgets.QApplication.setStyle("Fusion")
-            
+        os.environ['QT_AUTO_SCREEN_SCALE_FACTOR'] = '1'            
         app = QtWidgets.QApplication(sys.argv)
         if platform.system() == "Darwin":
             # Set the MacOS dock icon
@@ -81,6 +74,11 @@ def ctmain():
             import ctypes
             myappid = u'comictagger' # arbitrary string
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+            # force close of console window
+            SWP_HIDEWINDOW = 0x0080
+            consoleWnd = ctypes.windll.kernel32.GetConsoleWindow()
+            if consoleWnd != 0:          
+                ctypes.windll.user32.SetWindowPos(consoleWnd, None, 0, 0, 0, 0, SWP_HIDEWINDOW)
 
         if platform.system() != "Linux":
             img = QtGui.QPixmap(ComicTaggerSettings.getGraphic('tags.png'))

--- a/comictaggerlib/options.py
+++ b/comictaggerlib/options.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     pass
 
+from datetime import datetime
 from .genericmetadata import GenericMetadata
 from .comicarchive import MetaDataStyle
 from .versionchecker import VersionChecker
@@ -103,7 +104,7 @@ If no options are given, {0} will run in windowed mode.
     --version               Display version.
 -h, --help                  Display this message.
 
-For more help visit the wiki at: http://code.google.com/p/comictagger/
+For more help visit the wiki at: https://github.com/comictagger/comictagger/wiki
     """
 
     def __init__(self):
@@ -341,7 +342,7 @@ For more help visit the wiki at: http://code.google.com/p/comictagger/
                 self.only_set_key = True
             if o == "--version":
                 print((
-                    "ComicTagger {0}:  Copyright (c) 2012-2014 Anthony Beville".format(ctversion.version)))
+                    "ComicTagger {}:  Copyright (c) 2012-{:%Y} ComicTagger Team".format(ctversion.version, datetime.today())))
                 print(
                     "Distributed under Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)")
                 sys.exit(0)

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -2103,7 +2103,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
     def versionCheckComplete(self, new_version):
         if (new_version != self.version and
                 new_version != self.settings.dont_notify_about_this_version):
-            website = "http://code.google.com/p/comictagger"
+            website = "https://github.com/comictagger/comictagger"
             checked = OptionalMessageDialog.msg(
                 self,
                 "New version available!",


### PR DESCRIPTION
 * macOS pyinstaller build work as before, with `console=False`
 * windows pyinstaller build sets `console=True` and hides the console during startup. This allow for correctly using it as a CLI application from powershell, but also means that the console window will appear for a while and then it will disappear. I think this is a good trade off after all.

Fix #160.