### PR TITLE
PyPI release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,51 @@
 language: python
 branches:
   only:
-    - develop
-    - /^\d+\.\d+\.\d+$/
+  - develop
+  - "/^\\d+\\.\\d+\\.\\d+$/"
 env:
   global:
-    - PYTHON=python
-    - PIP=pip
-    - SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
-    - MAKE=make
+  - PYTHON=python
+  - PIP=pip
+  - SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
+  - MAKE=make
 matrix:
   include:
-    - os: linux
-    - os: osx
-      language: generic
-      osx_image: xcode8.3
-      env: PYTHON=python3 PIP=pip3 MACOSX_DEPLOYMENT_TARGET=10.11
-    - os: windows
-      language: bash
-      env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make
+  - os: linux
+  - os: osx
+    language: generic
+    osx_image: xcode8.3
+    env: PYTHON=python3 PIP=pip3 MACOSX_DEPLOYMENT_TARGET=10.11
+  - os: windows
+    language: bash
+    env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python mingw zip; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade python3 ; fi
+- if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python mingw zip; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade python3 ; fi
 install:
-  - $PIP install --upgrade setuptools
-  - $PIP install -r requirements.txt
+- "$PIP install --upgrade setuptools"
+- "$PIP install -r requirements.txt"
 script:
-  - $MAKE dist
-
+- if [ "$TRAVIS_OS_NAME" != "linux" ]; then $MAKE dist ; fi
 deploy:
-  name: $TRAVIS_TAG
-  body: Released ComicTagger $TRAVIS_TAG
-  provider: releases
-  skip_cleanup: true
-  api_key:
-    secure: RgohcOJOfLhXXT12bMWaLwOqhe+ClSCYXjYuUJuWK4/E1fdd1xu1ebdQU+MI/R8cZ0Efz3sr2n3NkO/Aa8gN68xEfuF7RVRMm64P9oPrfZgGdsD6H43rU/6kN8bgaDRmCYpLTfXaJ+/gq0x1QDkhWJuceF2BYEGGvL0BvS/TUsLyjVxs8ujTplLyguXHNEv4/7Yz7SBNZZmUHjBuq/y+l8ds3ra9rSgAVAN1tMXoFKJPv+SNNkpTo5WUNMPzBnN041F1rzqHwYDLog2V7Krp9JkXzheRFdAr51/tJBYzEd8AtYVdYvaIvoO6A4PiTZ7MpsmcZZPAWqLQU00UTm/PhT/LVR+7+f8lOBG07RgNNHB+edjDRz3TAuqyuZl9wURWTZKTPuO49TkZMz7Wm0DRNZHvBm1IXLeSG7Tll2YL1+WpZNZg+Dhro2J1QD3vxDXafhMdTCB4z0q5aKpG93IT0p6oXOO0oEGOPZYbA2c5R3SXWSyqd1E1gdhbVjIZr59h++TEf1zz07tvWHqPuAF/Ly/j+dIcY2wj0EzRWaSASWgUpTnMljAkHtWhqDw4GXGDRkRUWRJl1d0/JyVqCeIdRzDQNl8/q7BcO3F1zqr1PgnYdz0lfwWxL1/ekw2vHOJE/GOdkyvX0aJrnaOV338mjJbfGHYv4ESc9ow1kdtIbiU=
-  file_glob: true  
-  file: dist/*.zip
-  draft: true
-  on:    
-    tags: true
+  - name: "$TRAVIS_TAG"
+    body: Released ComicTagger $TRAVIS_TAG
+    provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: RgohcOJOfLhXXT12bMWaLwOqhe+ClSCYXjYuUJuWK4/E1fdd1xu1ebdQU+MI/R8cZ0Efz3sr2n3NkO/Aa8gN68xEfuF7RVRMm64P9oPrfZgGdsD6H43rU/6kN8bgaDRmCYpLTfXaJ+/gq0x1QDkhWJuceF2BYEGGvL0BvS/TUsLyjVxs8ujTplLyguXHNEv4/7Yz7SBNZZmUHjBuq/y+l8ds3ra9rSgAVAN1tMXoFKJPv+SNNkpTo5WUNMPzBnN041F1rzqHwYDLog2V7Krp9JkXzheRFdAr51/tJBYzEd8AtYVdYvaIvoO6A4PiTZ7MpsmcZZPAWqLQU00UTm/PhT/LVR+7+f8lOBG07RgNNHB+edjDRz3TAuqyuZl9wURWTZKTPuO49TkZMz7Wm0DRNZHvBm1IXLeSG7Tll2YL1+WpZNZg+Dhro2J1QD3vxDXafhMdTCB4z0q5aKpG93IT0p6oXOO0oEGOPZYbA2c5R3SXWSyqd1E1gdhbVjIZr59h++TEf1zz07tvWHqPuAF/Ly/j+dIcY2wj0EzRWaSASWgUpTnMljAkHtWhqDw4GXGDRkRUWRJl1d0/JyVqCeIdRzDQNl8/q7BcO3F1zqr1PgnYdz0lfwWxL1/ekw2vHOJE/GOdkyvX0aJrnaOV338mjJbfGHYv4ESc9ow1kdtIbiU=
+    file_glob: true
+    file: dist/*.zip
+    draft: true
+    on:
+      tags: true
+      condition: $TRAVIS_OS_NAME != "linux"
+  - provider: pypi
+    user: __token__
+    password:
+      secure: h+y5WkE8igf864dnsbGPFvOBkyPkuBYtnDRt+EgxHd71EZnV2YP7ns2Cx12su/SVVDdZCBlmHVtkhl6Jmqy+0rTkSYx+3mlBOqyl8Cj5+BlP/dP7Bdmhs2uLZk2YYL1avbC0A6eoNJFtCkjurnB/jCGE433rvMECWJ5x2HsQTKchCmDAEdAZbRBJrzLFsrIC+6NXW1IJZjd+OojbhLSyVar2Jr32foh6huTcBu/x278V1+zIC/Rwy3W67+3c4aZxYrI47FoYFza0jjFfr3EoSkKYUSByMTIvhWaqB2gIsF0T160jgDd8Lcgej+86ACEuG0v01VE7xoougqlOaJ94eAmapeM7oQXzekSwSAxcK3JQSfgWk/AvPhp07T4pQ8vCZmky6yqvVp1EzfKarTeub1rOnv+qo1znKLrBtOoq6t8pOAeczDdIDs51XT/hxaijpMRCM8vHxN4Kqnc4DY+3KcF7UFyH1ifQJHQe71tLBsM/GnAcJM5/3ykFVGvRJ716p4aa6IoGsdNk6bqlysNh7nURDl+bfm+CDXRkO2jkFwUFNqPHW7JwY6ZFx+b5SM3TzC3obJhfMS7OC37fo2geISOTR0xVie6NvpN6TjNAxFTfDxWJI7yH3Al2w43B3uYDd97WeiN+B+HVWtdaER87IVSRbRqFrRub+V+xrozT0y0=
+    skip_existing: true
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: $TRAVIS_OS_NAME = "linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
 language: python
 branches:
   only:
-  - develop
-  - "/^\\d+\\.\\d+\\.\\d+$/"
+    - develop
+    - /^\d+\.\d+\.\d+$/
 env:
   global:
-  - PYTHON=python
-  - PIP=pip
-  - SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
-  - MAKE=make
+    - PYTHON=python
+    - PIP=pip
+    - SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
+    - MAKE=make
 matrix:
   include:
-  - os: linux
-  - os: osx
-    language: generic
-    osx_image: xcode8.3
-    env: PYTHON=python3 PIP=pip3 MACOSX_DEPLOYMENT_TARGET=10.11
-  - os: windows
-    language: bash
-    env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make
+    - os: linux
+    - os: osx
+      language: generic
+      osx_image: xcode8.3
+      env: PYTHON=python3 PIP=pip3 MACOSX_DEPLOYMENT_TARGET=10.11
+    - os: windows
+      language: bash
+      env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make
 before_install:
-- if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python mingw zip; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade python3 ; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python mingw zip; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade python3 ; fi
 install:
-- "$PIP install --upgrade setuptools"
-- "$PIP install -r requirements.txt"
+  - $PIP install --upgrade setuptools
+  - $PIP install -r requirements.txt
 script:
-- if [ "$TRAVIS_OS_NAME" != "linux" ]; then $MAKE dist ; fi
+  - if [ "$TRAVIS_OS_NAME" != "linux" ]; then $MAKE dist ; fi
+
 deploy:
   - name: "$TRAVIS_TAG"
     body: Released ComicTagger $TRAVIS_TAG

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ComicTagger is a **multi-platform** app for **writing metadata to digital comics**, written in Python and PyQt.
 
-![ComicTagger logo](comictaggerlib/graphics/app.png?raw=true)
+![ComicTagger logo](https://raw.githubusercontent.com/comictagger/comictagger/develop/comictaggerlib/graphics/app.png)
 
 ## Features
 

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,11 @@ import tempfile
 
 python_requires='>=3',
 
-
 with open('requirements.txt') as f:
     required = f.read().splitlines()
-# Always require PyQt5 on Windows and Mac
-if platform.system() in [ "Windows", "Darwin" ]:
-    required.append("PyQt5")
+
+with open('README.md') as f:
+    long_description = f.read()
 
 platform_data_files = []
 
@@ -175,19 +174,6 @@ setup(name="comictagger",
       ],
       keywords=['comictagger', 'comics', 'comic', 'metadata', 'tagging', 'tagger'],
       license="Apache License 2.0",
-
-      long_description="""
-ComicTagger is a multi-platform app for writing metadata to digital comics, written in Python and PyQt.
-
-Features:
-
-* Runs on Mac OSX, Microsoft Windows, and Linux systems
-* Communicates with an online database (Comic Vine) for acquiring metadata
-* Uses image processing to automatically match a given archive with the correct issue data
-* Batch processing in the GUI for tagging hundreds or more comics at a time
-* Reads and writes multiple tagging schemes ( ComicBookLover and ComicRack).
-* Reads and writes RAR and Zip archives (external tools needed for writing RAR)
-* Command line interface (CLI) on all platforms (including Windows), which supports batch operations, and which can be used in native scripts for complex operations.
-* Can run without PyQt5 installed 
-"""
-      )
+      long_description=long_description,
+      long_description_content_type="text/markdown"
+)


### PR DESCRIPTION
 * following #150, don't release pyinstaller for linux but only pypi
 * release pyinstaller only for macOS and Windows versions

This way users have the choice:
 * macOS and Windows users can use the binary version or the pip version
 * linux users can install only from pip/pipx

Replaces #138 closes #148, #150 