### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: python
+# Only build tags
+if: type = pull_request OR tag IS present
 branches:
   only:
     - develop
     - /^\d+\.\d+\.\d+.*$/
 env:
   global:
-    - PYTHON=python
-    - PIP=pip
+    - PYTHON=python3
+    - PIP=pip3
     - SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
     - MAKE=make
 matrix:
   include:
     - os: linux
-    - os: osx
-      language: generic
-      osx_image: xcode8.3
-      env: PYTHON=python3 PIP=pip3 MACOSX_DEPLOYMENT_TARGET=10.11
+      python: 3.8
+    - name: "Python: 3.7"
+      os: osx
+      language: shell
+      python: 3.7
+      env: PYTHON=python3 PIP="python3 -m pip"
+      cache:
+        - directories:
+          - $HOME/Library/Caches/pip
     - os: windows
       language: bash
-      env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make
+      env: PATH=/C/Python37:/C/Python37/Scripts:$PATH MAKE=mingw32-make PIP=pip PYTHON=python
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python mingw zip; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade python3 ; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install -y python --version 3.7.9; choco install -y mingw zip; fi
 install:
   - $PIP install --upgrade setuptools
   - $PIP install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-PIP ?= pip
-VERSION_STR := $(shell python setup.py --version)
+PIP ?= pip3
+PYTHON ?= python3
+VERSION_STR := $(shell $(PYTHON) setup.py --version)
 
 ifeq ($(OS),Windows_NT)
 	OS_VERSION=win-$(PROCESSOR_ARCHITECTURE)
@@ -34,13 +35,13 @@ pydist:
 	make clean
 	mkdir -p piprelease
 	rm -f comictagger-$(VERSION_STR).zip
-	python setup.py sdist --formats=zip  #,gztar
+	$(PYTHON) setup.py sdist --formats=zip  #,gztar
 	mv dist/comictagger-$(VERSION_STR).zip piprelease
 	rm -rf comictagger.egg-info dist
 		
 upload:
-	python setup.py register
-	python setup.py sdist --formats=zip upload
+	$(PYTHON) setup.py register
+	$(PYTHON) setup.py sdist --formats=zip upload
 
 dist:
 	$(PIP) install .

--- a/comictagger.spec
+++ b/comictagger.spec
@@ -9,13 +9,6 @@ binaries = []
 block_cipher = None
 
 if platform.system() == "Windows":
-    from site import getsitepackages
-    sitepackages = getsitepackages()[1]
-    # add ssl qt libraries not discovered automatically
-    binaries.extend([
-        (join(sitepackages, "PyQt5/Qt/bin/libeay32.dll"), "./PyQt5/Qt/bin"),
-        (join(sitepackages, "PyQt5/Qt/bin/ssleay32.dll"), "./PyQt5/Qt/bin")
-    ])
     enable_console = True
 
 a = Analysis(['comictagger.py'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ natsort==3.5.2
 PyPDF2==1.24
 pillow>=4.3.0
 PyQt5>=5.12.2
-pyinstaller>=3.5
+pyinstaller==4.3
 unrar-cffi==0.1.0a5


### PR DESCRIPTION
hold windows to 3.7.9 as unrar-cffi only has windows wheels for 3.7
switch to using builtin python for macOS
remove ssl dlls from comictagger.spec
require pyinstaller=4.3 to allow macOS codesigning