### PR TITLE
Explicitly specify unsigned integer sort to fix comic page order

### DIFF
--- a/comicapi/comicarchive.py
+++ b/comicapi/comicarchive.py
@@ -786,7 +786,7 @@ class ComicArchive:
                 def keyfunc(k):
                     return k.lower()
 
-                files = natsort.natsorted(files, alg=natsort.ns.IC | natsort.ns.I)
+                files = natsort.natsorted(files, alg=natsort.ns.IC | natsort.ns.I | natsort.ns.U)
 
             # make a sub-list of image files
             self.page_list = []


### PR DESCRIPTION
I was encountering an issue where the pages of comics were all out of order. Almost exactly reversed in fact. It seems that, for whatever reason, the sort is occurring in a signed manner (e.g. issue 1 page 1 vs issue 1 page 2 - "#001-01" "#001-02" was sorting with -2 before -1).

My reading of the docs seem to indicate that unsigned should be the default, but it isn't working that way on my machine.

This small patch simply explicitly specifies the behavior we want and now it seems to work fine again.