### PR TITLE
Fix parsing of filenames that end with an ID such as [__######__]

### DIFF
--- a/comicapi/filenameparser.py
+++ b/comicapi/filenameparser.py
@@ -89,7 +89,7 @@ class FileNameParser:
             # is the series name followed by issue
             filename = re.sub(r"--.*", self.repl, filename)
 
-        elif "__" in filename and not re.search('\\[__\\d+__\\]', filename):
+        elif "__" in filename and not re.search(r"\[__\d+__\]", filename):
             # the pattern seems to be that anything to left of the first "__"
             # is the series name followed by issue
             filename = re.sub(r"__.*", self.repl, filename)

--- a/comicapi/filenameparser.py
+++ b/comicapi/filenameparser.py
@@ -89,7 +89,7 @@ class FileNameParser:
             # is the series name followed by issue
             filename = re.sub(r"--.*", self.repl, filename)
 
-        elif "__" in filename:
+        elif "__" in filename and not re.search('\\[__\\d+__\\]', filename):
             # the pattern seems to be that anything to left of the first "__"
             # is the series name followed by issue
             filename = re.sub(r"__.*", self.repl, filename)


### PR DESCRIPTION
As of late, I have been getting failures to extract metadata from filenames that end with what seems to be a Comic Vine ID with some surrounding formatting.

An example: 'The Magic Order 2 06 (of 06) (2022) (Digital) (Zone-Empire)[__913302__].cbz'

The cause is some part of the matching that looks for '__' and applies some special formatting rules. This seems to pre-date the use of that text in the manner shown above and causes the parsing to go off the rails.

This fix simply tells it to also check that it isn't seeing the above format when it identifies that the string contains '__' and continue on as normal if it does.

Without the fix, the result of parsing is:
issue = ''
issue_count = ''
series = 'The Magic Order 2 06  ['
volume = ''
year = '2022'
Note that running a search using this metadata will fail. I think it might actually be causing the Comic Vine API to error out.

With the fix, the result of parsing is:
issue = '6'
issue_count = '6'
series = 'The Magic Order 2'
volume = ''
year = '2022'

Note that if there is filename that uses BOTH the trailing Comic Vine ID as well as the '__' pattern for the other usage, it will probably not parse correctly. On the other hand, in that circumstance it isn't parsing correctly now anyway... 