### PR TITLE
Partial revert of 'e616aa8373688fe0ee7394ddad5b409653354271'

### DIFF
--- a/comicapi/comicinfoxml.py
+++ b/comicapi/comicinfoxml.py
@@ -18,7 +18,7 @@ import logging
 import xml.etree.ElementTree as ET
 
 from comicapi import utils
-from comicapi.genericmetadata import GenericMetadata, PageType
+from comicapi.genericmetadata import GenericMetadata
 from comicapi.issuestring import IssueString
 
 logger = logging.getLogger(__name__)
@@ -171,8 +171,6 @@ class ComicInfoXml:
 
         for page_dict in md.pages:
             page = page_dict
-            if "Type" in page:
-                page["Type"] = page["Type"].value
             if "Image" in page:
                 page["Image"] = str(page["Image"])
             page_node = ET.SubElement(pages_node, "Page")
@@ -256,8 +254,6 @@ class ComicInfoXml:
         pages_node = root.find("Pages")
         if pages_node is not None:
             for page in pages_node:
-                if "Type" in page.attrib:
-                    page.attrib["Type"] = PageType(page.attrib["Type"])
                 if "Image" in page.attrib:
                     page.attrib["Image"] = int(page.attrib["Image"])
                 md.pages.append(page.attrib)

--- a/comicapi/genericmetadata.py
+++ b/comicapi/genericmetadata.py
@@ -21,7 +21,6 @@ possible, however lossy it might be
 # limitations under the License.
 
 import logging
-from enum import Enum
 from typing import List, TypedDict
 
 from comicapi import utils
@@ -29,7 +28,7 @@ from comicapi import utils
 logger = logging.getLogger(__name__)
 
 
-class PageType(Enum):
+class PageType:
 
     """
     These page info classes are exactly the same as the CIX scheme, since
@@ -50,7 +49,7 @@ class PageType(Enum):
 
 
 class ImageMetadata(TypedDict, total=False):
-    Type: PageType
+    Type: str
     Bookmark: str
     DoublePage: bool
     Image: int

--- a/tests/test_comicarchive.py
+++ b/tests/test_comicarchive.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join
 import pytest
 
 from comicapi.comicarchive import ComicArchive, rar_support
-from comicapi.genericmetadata import GenericMetadata, PageType, md_test
+from comicapi.genericmetadata import GenericMetadata, md_test
 
 thisdir = dirname(abspath(__file__))
 
@@ -35,12 +35,12 @@ def test_set_default_page_list(tmpdir):
     assert isinstance(md.pages[0]["Image"], int)
 
 
-def test_page_type():
+def test_page_type_read():
     c_path = join(thisdir, "data", "Cory Doctorow's Futuristic Tales of the Here and Now #001 - Anda's Game (2007).cbz")
     c = ComicArchive(str(c_path))
     md = c.read_cix()
 
-    assert isinstance(md.pages[0]["Type"], PageType)
+    assert isinstance(md.pages[0]["Type"], str)
 
 
 def test_save_cix(tmpdir):
@@ -53,6 +53,23 @@ def test_save_cix(tmpdir):
     c = ComicArchive(str(comic_path))
     md = c.read_cix()
     md.set_default_page_list(c.get_number_of_pages())
+
+    assert c.write_cix(md)
+
+    md = c.read_cix()
+
+
+def test_page_type_save(tmpdir):
+    comic_path = tmpdir.mkdir("cbz").join(
+        "Cory Doctorow's Futuristic Tales of the Here and Now #001 - Anda's Game (2007).cbz"
+    )
+    c_path = join(thisdir, "data", "Cory Doctorow's Futuristic Tales of the Here and Now #001 - Anda's Game (2007).cbz")
+    shutil.copy(c_path, comic_path)
+
+    c = ComicArchive(str(comic_path))
+    md = c.read_cix()
+    t = md.pages[0]
+    t["Type"] = ""
 
     assert c.write_cix(md)
 


### PR DESCRIPTION
Changing PageType to an Enum creates too many issues

fixes #274