### PR TITLE
 Adds the Chocolatey package as a way to install ComicTagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/downloads/comictagger/comictagger/latest/total)](https://github.com/comictagger/comictagger/releases/latest)
 [![PyPI](https://img.shields.io/pypi/v/comictagger)](https://pypi.org/project/comictagger/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/comictagger)](https://pypistats.org/packages/comictagger)
+[![Chocolatey package](https://img.shields.io/chocolatey/dt/comictagger?color=blue&label=chocolatey)](https://community.chocolatey.org/packages/comictagger)
 [![PyPI - License](https://img.shields.io/pypi/l/comictagger)](https://opensource.org/licenses/Apache-2.0)
 
 [![GitHub Discussions](https://img.shields.io/github/discussions/comictagger/comictagger)](https://github.com/comictagger/comictagger/discussions)
@@ -47,6 +48,13 @@ A pip package is provided, you can install it with:
 ```
 
 There are two optional dependencies GUI and CBR. You can install the optional dependencies by specifying one or more of `GUI`,`CBR` or `all` in braces e.g. `comictagger[CBR,GUI]`
+
+### Chocolatey installation (Windows only)
+
+A [Chocolatey package](https://community.chocolatey.org/packages/comictagger) is provided, you can install it with
+```powershell
+choco install comictagger
+```
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ There are two optional dependencies GUI and CBR. You can install the optional de
 
 ### Chocolatey installation (Windows only)
 
-A [Chocolatey package](https://community.chocolatey.org/packages/comictagger) is provided, you can install it with
+A [Chocolatey package](https://community.chocolatey.org/packages/comictagger), maintained by @Xav83, is provided, you can install it with:
 ```powershell
 choco install comictagger
-```
 
 ### From source
 


### PR DESCRIPTION
Hi @ComicTagger_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1332) and now, we can install **comictagger** using [Chocolatey](https://community.chocolatey.org/packages/comictagger).

For now, only the 2 versions `1.4.4` and `1.4.5` are available on Chocolatey. The version `1.4.6` is currently following the validation process. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

