### PR TITLE
Fix some keys logic in issue identifier

### DIFF
--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -177,8 +177,6 @@ class IssueIdentifier:
 
         ca = self.comic_archive
 
-        if ca is None:
-            return None
         search_keys: SearchKeys
         if self.only_use_additional_meta_data:
             search_keys = SearchKeys(
@@ -350,16 +348,13 @@ class IssueIdentifier:
                 narrow_cover_hash = self.calculate_hash(right_side_image_data)
 
         keys = self.get_search_keys()
-        if keys is None:
-            return []
-
-        # we need, at minimum, a series and issue number
-        if keys["series"] is None or keys["issue_number"] is None:
-            self.log_msg("Not enough info for a search!")
-            return []
-
         # normalize the issue number, None will return as ""
         keys["issue_number"] = IssueString(keys["issue_number"]).as_string()
+
+        # we need, at minimum, a series and issue number
+        if not (keys["series"] and keys["issue_number"]):
+            self.log_msg("Not enough info for a search!")
+            return []
 
         self.log_msg("Going to search for:")
         self.log_msg("\tSeries: " + keys["series"])

--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -350,13 +350,16 @@ class IssueIdentifier:
                 narrow_cover_hash = self.calculate_hash(right_side_image_data)
 
         keys = self.get_search_keys()
-        # normalize the issue number
-        keys["issue_number"] = IssueString(keys["issue_number"]).as_string()
+        if keys is None:
+            return []
 
         # we need, at minimum, a series and issue number
         if keys["series"] is None or keys["issue_number"] is None:
             self.log_msg("Not enough info for a search!")
             return []
+
+        # normalize the issue number, None will return as ""
+        keys["issue_number"] = IssueString(keys["issue_number"]).as_string()
 
         self.log_msg("Going to search for:")
         self.log_msg("\tSeries: " + keys["series"])


### PR DESCRIPTION
keys may be None if there is no comic archive. 

IssueString.as_string will convert None to empty string so use None comparison before.