### PR TITLE
Sort volume window by fuzz ratio first

### DIFF
--- a/comicapi/utils.py
+++ b/comicapi/utils.py
@@ -162,10 +162,14 @@ def sanitize_title(text: str, basic: bool = False) -> str:
     return text
 
 
-def titles_match(search_title: str, record_title: str, threshold: int = 90) -> bool:
-    sanitized_search = sanitize_title(search_title)
-    sanitized_record = sanitize_title(record_title)
-    ratio: int = rapidfuzz.fuzz.ratio(sanitized_search, sanitized_record)
+def titles_match(search_title: str, record_title: str, threshold: int = 90, basic: bool = True) -> tuple[bool, float]:
+    if basic:
+        sanitized_search = sanitize_title(search_title)
+        sanitized_record = sanitize_title(record_title)
+    else:
+        sanitized_search = sanitize_title(search_title, True)
+        sanitized_record = sanitize_title(record_title, True)
+    ratio: float = rapidfuzz.fuzz.ratio(sanitized_search, sanitized_record)
     logger.debug(
         "search title: %s ; record title: %s ; ratio: %d ; match threshold: %d",
         search_title,
@@ -173,7 +177,7 @@ def titles_match(search_title: str, record_title: str, threshold: int = 90) -> b
         ratio,
         threshold,
     )
-    return ratio >= threshold
+    return ratio >= threshold, ratio
 
 
 def unique_file(file_name: pathlib.Path) -> pathlib.Path:

--- a/comictaggerlib/settings.py
+++ b/comictaggerlib/settings.py
@@ -89,7 +89,6 @@ class ComicTaggerSettings:
         self.auto_imprint = False
 
         self.sort_series_by_year = True
-        self.exact_series_matches_first = True
         self.always_use_publisher_filter = False
 
         # CBL Transform settings
@@ -242,8 +241,6 @@ class ComicTaggerSettings:
 
         if self.config.has_option("comicvine", "sort_series_by_year"):
             self.sort_series_by_year = self.config.getboolean("comicvine", "sort_series_by_year")
-        if self.config.has_option("comicvine", "exact_series_matches_first"):
-            self.exact_series_matches_first = self.config.getboolean("comicvine", "exact_series_matches_first")
         if self.config.has_option("comicvine", "always_use_publisher_filter"):
             self.always_use_publisher_filter = self.config.getboolean("comicvine", "always_use_publisher_filter")
 
@@ -372,7 +369,6 @@ class ComicTaggerSettings:
         self.config.set("comicvine", "remove_html_tables", self.remove_html_tables)
 
         self.config.set("comicvine", "sort_series_by_year", self.sort_series_by_year)
-        self.config.set("comicvine", "exact_series_matches_first", self.exact_series_matches_first)
         self.config.set("comicvine", "always_use_publisher_filter", self.always_use_publisher_filter)
 
         self.config.set("comicvine", "cv_api_key", self.cv_api_key)

--- a/comictaggerlib/settingswindow.py
+++ b/comictaggerlib/settingswindow.py
@@ -246,7 +246,6 @@ class SettingsWindow(QtWidgets.QDialog):
 
         self.cbxUseFilter.setChecked(self.settings.always_use_publisher_filter)
         self.cbxSortByYear.setChecked(self.settings.sort_series_by_year)
-        self.cbxExactMatches.setChecked(self.settings.exact_series_matches_first)
 
         self.leKey.setText(self.settings.cv_api_key)
         self.leURL.setText(self.settings.cv_url)
@@ -326,7 +325,6 @@ class SettingsWindow(QtWidgets.QDialog):
 
         self.settings.always_use_publisher_filter = self.cbxUseFilter.isChecked()
         self.settings.sort_series_by_year = self.cbxSortByYear.isChecked()
-        self.settings.exact_series_matches_first = self.cbxExactMatches.isChecked()
 
         # Ignore empty field
         if self.leKey.text().strip():

--- a/comictaggerlib/ui/settingswindow.ui
+++ b/comictaggerlib/ui/settingswindow.ui
@@ -361,14 +361,7 @@
               <item>
                <widget class="QCheckBox" name="cbxSortByYear">
                 <property name="text">
-                 <string>Initially sort Series search results by Starting Year instead of No. Issues</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="cbxExactMatches">
-                <property name="text">
-                 <string>Initially show Series Name exact matches first</string>
+                 <string>Secondarily sort Series search results by Starting Year instead of No. Issues</string>
                 </property>
                </widget>
               </item>
@@ -536,7 +529,7 @@
               <x>11</x>
               <y>21</y>
               <width>251</width>
-              <height>199</height>
+              <height>206</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_7">

--- a/comictalker/comiccacher.py
+++ b/comictalker/comiccacher.py
@@ -92,6 +92,7 @@ class ComicCacher:
                 + "image_url TEXT,"
                 + "aliases TEXT,"  # Newline separated
                 + "description TEXT,"
+                + "fuzz_ratio REAL,"
                 + "timestamp DATE DEFAULT (datetime('now','localtime')), "
                 + "source_name TEXT NOT NULL,"
                 + "PRIMARY KEY (id, source_name))"
@@ -154,6 +155,7 @@ class ComicCacher:
                     "start_year": record.get("start_year"),
                     "image_url": record.get("image_url", ""),
                     "description": record.get("description", ""),
+                    "fuzz_ratio": record.get("fuzz_ratio"),
                     "timestamp": datetime.datetime.now(),
                     "aliases": "\n".join(record.get("aliases", [])),
                 }
@@ -185,6 +187,7 @@ class ComicCacher:
                     image_url=record[9],
                     aliases=record[10].strip().splitlines(),
                     description=record[11],
+                    fuzz_ratio=record[12],
                 )
 
                 results.append(result)

--- a/comictalker/resulttypes.py
+++ b/comictalker/resulttypes.py
@@ -17,6 +17,7 @@ class ComicVolume(TypedDict, total=False):
     name: Required[str]
     publisher: str
     start_year: int
+    fuzz_ratio: float
 
 
 class ComicIssue(TypedDict, total=False):


### PR DESCRIPTION
This is just to get going.

- If the ratio is to be cached it probably belongs in the `VolumeSearchCache` table.
- If the talker doesn't fetch the ratio, `volumeselectionwindow` could do it (and ratio wouldn't need to be cached).

As far as I see, `issueidentifier` doesn't get involved unless some form of auto-identify is involved.