### PR TITLE
Hide coverimagewidget text when there is a singles image. Fixes #424

### DIFF
--- a/comictaggerlib/coverimagewidget.py
+++ b/comictaggerlib/coverimagewidget.py
@@ -218,11 +218,13 @@ class CoverImageWidget(QtWidgets.QWidget):
             self.btnRight.setEnabled(False)
             self.btnLeft.hide()
             self.btnRight.hide()
+            self.label.hide()
         else:
             self.btnLeft.setEnabled(True)
             self.btnRight.setEnabled(True)
             self.btnLeft.show()
             self.btnRight.show()
+            self.label.show()
 
         if self.imageIndex == -1 or self.imageCount == 1:
             self.label.setText("")


### PR DESCRIPTION
It might be intended that `showControls = False` is meant to be used instead? The question is with say the issue view, is it preferred that the image scales to the size of the widget or leave the space for the controls?

If using `showControls` would it not be better to have it passed in on `init`?