### PR TITLE
Hide invisible controls to prevent bottom margin on source logos

### DIFF
--- a/comictaggerlib/issueselectionwindow.py
+++ b/comictaggerlib/issueselectionwindow.py
@@ -86,6 +86,7 @@ class IssueSelectionWindow(QtWidgets.QDialog):
             talker_api,
             False,
         )
+        self.imageIssuesSourceWidget.showControls = False
         gridlayoutIssuesSourceLogo = QtWidgets.QGridLayout(self.imageIssuesSourceLogo)
         gridlayoutIssuesSourceLogo.addWidget(self.imageIssuesSourceWidget)
         gridlayoutIssuesSourceLogo.setContentsMargins(0, 2, 0, 0)

--- a/comictaggerlib/seriesselectionwindow.py
+++ b/comictaggerlib/seriesselectionwindow.py
@@ -171,6 +171,7 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
             talker_api,
             False,
         )
+        self.imageSourceWidget.showControls = False
         gridlayoutSourceLogo = QtWidgets.QGridLayout(self.imageSourceLogo)
         gridlayoutSourceLogo.addWidget(self.imageSourceWidget)
         gridlayoutSourceLogo.setContentsMargins(0, 2, 0, 0)


### PR DESCRIPTION
This fixes the bottom margin problem as mentioned before.