### PR TITLE
Support talkers without issue level details

### DIFF
--- a/comictaggerlib/seriesselectionwindow.py
+++ b/comictaggerlib/seriesselectionwindow.py
@@ -195,6 +195,15 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
         self.btnIssues.setEnabled(enabled)
         self.btnAutoSelect.setEnabled(enabled)
 
+        if self.talker.has_issues:
+            self.btnIssues.setEnabled(enabled)
+            self.btnAutoSelect.setEnabled(enabled)
+        else:
+            self.btnIssues.setEnabled(False)
+            self.btnIssues.setToolTip("Unsupported by " + self.talker.name)
+            self.btnAutoSelect.setEnabled(False)
+            self.btnAutoSelect.setToolTip("Unsupported by " + self.talker.name)
+
         self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).setEnabled(enabled)
 
     def requery(self) -> None:
@@ -210,36 +219,39 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
             QtWidgets.QMessageBox.information(self, "Auto-Select", "You need to load a comic first!")
             return
 
-        if self.issue_number is None or self.issue_number == "":
-            QtWidgets.QMessageBox.information(self, "Auto-Select", "Can't auto-select without an issue number (yet!)")
-            return
+        if self.talker.has_issues:
+            if not self.issue_number:
+                QtWidgets.QMessageBox.information(
+                    self, "Auto-Select", "Can't auto-select without an issue number (yet!)"
+                )
+                return
 
-        self.iddialog = IDProgressWindow(self)
-        self.iddialog.setModal(True)
-        self.iddialog.rejected.connect(self.identify_cancel)
-        self.iddialog.show()
+            self.iddialog = IDProgressWindow(self)
+            self.iddialog.setModal(True)
+            self.iddialog.rejected.connect(self.identify_cancel)
+            self.iddialog.show()
 
-        self.ii = IssueIdentifier(self.comic_archive, self.config, self.talker)
+            self.ii = IssueIdentifier(self.comic_archive, self.config, self.talker)
 
-        md = GenericMetadata()
-        md.series = self.series_name
-        md.issue = self.issue_number
-        md.year = self.year
-        md.issue_count = self.issue_count
+            md = GenericMetadata()
+            md.series = self.series_name
+            md.issue = self.issue_number
+            md.year = self.year
+            md.issue_count = self.issue_count
 
-        self.ii.set_additional_metadata(md)
-        self.ii.only_use_additional_meta_data = True
+            self.ii.set_additional_metadata(md)
+            self.ii.only_use_additional_meta_data = True
 
-        self.ii.cover_page_index = int(self.cover_index_list[0])
+            self.ii.cover_page_index = int(self.cover_index_list[0])
 
-        self.id_thread = IdentifyThread(self.ii)
-        self.id_thread.identifyComplete.connect(self.identify_complete)
-        self.id_thread.identifyLogMsg.connect(self.log_id_output)
-        self.id_thread.identifyProgress.connect(self.identify_progress)
+            self.id_thread = IdentifyThread(self.ii)
+            self.id_thread.identifyComplete.connect(self.identify_complete)
+            self.id_thread.identifyLogMsg.connect(self.log_id_output)
+            self.id_thread.identifyProgress.connect(self.identify_progress)
 
-        self.id_thread.start()
+            self.id_thread.start()
 
-        self.iddialog.exec()
+            self.iddialog.exec()
 
     def log_id_output(self, text: str) -> None:
         if self.iddialog is not None:
@@ -515,7 +527,11 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
         self.auto_select()
 
     def cell_double_clicked(self, r: int, c: int) -> None:
-        self.show_issues()
+        if self.talker.has_issues:
+            self.show_issues()
+        else:
+            # Pass back to have taggerwindow get full series data
+            self.accept()
 
     def current_item_changed(self, curr: QtCore.QModelIndex | None, prev: QtCore.QModelIndex | None) -> None:
         if curr is None:

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1014,8 +1014,8 @@ class TaggerWindow(QtWidgets.QMainWindow):
     def query_online(self, autoselect: bool = False, literal: bool = False) -> None:
         issue_number = str(self.leIssueNum.text()).strip()
 
-        # Only need this check is the source has issue level data.
-        if autoselect and issue_number == "":
+        # Only need this check if the source has issue level data.
+        if autoselect and issue_number == "" and self.current_talker().has_issues:
             QtWidgets.QMessageBox.information(
                 self, "Automatic Identify Search", "Can't auto-identify without an issue number (yet!)"
             )
@@ -1661,7 +1661,11 @@ class TaggerWindow(QtWidgets.QMainWindow):
         QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
 
         try:
-            ct_md = self.current_talker().fetch_comic_data(match["issue_id"])
+            if self.current_talker().has_issues:
+                ct_md = self.current_talker().fetch_comic_data(match["issue_id"])
+            else:
+                ct_md = self.current_talker().fetch_comic_data(series_id=match["series_id"])
+
         except TalkerError:
             logger.exception("Save aborted.")
 

--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -110,6 +110,7 @@ class ComicTalker:
     logo_url: str = "https://example.com/logo.png"
     website: str = "https://example.com/"
     attribution: str = f"Metadata provided by <a href='{website}'>{name}</a>"
+    has_issues: bool = True
 
     def __init__(self, version: str, cache_folder: pathlib.Path) -> None:
         self.cache_folder = cache_folder

--- a/comictalker/talkers/comicvine.py
+++ b/comictalker/talkers/comicvine.py
@@ -159,6 +159,7 @@ class ComicVineTalker(ComicTalker):
     logo_url: str = "https://comicvine.gamespot.com/a/bundles/comicvinesite/images/logo.png"
     website: str = "https://comicvine.gamespot.com/"
     attribution: str = f"Metadata provided by <a href='{website}'>{name}</a>"
+    has_issues: bool = True
 
     def __init__(self, version: str, cache_folder: pathlib.Path):
         super().__init__(version, cache_folder)


### PR DESCRIPTION
I believe this is where we landed on the non-issue containing talkers. A talker without issues is still expected to return a list from `fetch_issues_by_series_issue_num_and_year`.