### PR TITLE
FIX: Apply credit datatype to person data from cache

### DIFF
--- a/comictalker/comiccacher.py
+++ b/comictalker/comiccacher.py
@@ -378,7 +378,12 @@ class ComicCacher:
                 )
 
                 # now process the results
-
+                credits = []
+                try:
+                    for credit in json.loads(row[13]):
+                        credits.append(Credit(**credit))
+                except Exception:
+                    logger.exception("credits failed")
                 record = ComicIssue(
                     id=row[1],
                     name=row[2],
@@ -392,7 +397,7 @@ class ComicCacher:
                     alt_image_urls=row[10].strip().splitlines(),
                     characters=row[11].strip().splitlines(),
                     locations=row[12].strip().splitlines(),
-                    credits=json.loads(row[13]),
+                    credits=credits,
                     teams=row[14].strip().splitlines(),
                     story_arcs=row[15].strip().splitlines(),
                     complete=bool(row[16]),


### PR DESCRIPTION
If the persons data is used from the cache it will cause a crash because the datatype of Credit isn't applied to the data.