### PR TITLE
FIX: Do not fail when talker key or URL is missing when set to False

### DIFF
--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -132,7 +132,7 @@ class ComicTalker:
         """
         if settings.get(f"{self.id}_key"):
             self.api_key = settings[f"{self.id}_key"]
-        if settings[f"{self.id}_url"]:
+        if settings.get(f"{self.id}_url"):
             self.api_url = fix_url(settings[f"{self.id}_url"])
 
         settings[f"{self.id}_url"] = self.api_url

--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -130,7 +130,7 @@ class ComicTalker:
         settings is a dictionary of settings defined in register_settings.
         It is only guaranteed that the settings defined in register_settings will be present.
         """
-        if settings[f"{self.id}_key"]:
+        if settings.get(f"{self.id}_key"):
             self.api_key = settings[f"{self.id}_key"]
         if settings[f"{self.id}_url"]:
             self.api_url = fix_url(settings[f"{self.id}_url"])


### PR DESCRIPTION
If `parser.add_setting(f"--{self.id}-key", file=False, cmdline=False)` to used by a talker because it doesn't require a key a `KeyError` will occur and the talker is then not available.