### PR TITLE
Hide the API key field text as a password and add a show/hide button

### DIFF
--- a/comictaggerlib/graphics/eye.svg
+++ b/comictaggerlib/graphics/eye.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Capa_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 469.333 469.333"
+   style="enable-background:new 0 0 469.333 469.333;"
+   xml:space="preserve"
+   sodipodi:docname="eye.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs45" /><sodipodi:namedview
+   id="namedview43"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   showgrid="false"
+   inkscape:zoom="2.1882117"
+   inkscape:cx="234.6665"
+   inkscape:cy="234.6665"
+   inkscape:window-width="2560"
+   inkscape:window-height="1361"
+   inkscape:window-x="0"
+   inkscape:window-y="42"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Capa_1" />
+<g
+   id="g10"
+   style="fill:#333333">
+	<g
+   id="g8"
+   style="fill:#333333">
+		<g
+   id="g6"
+   style="fill:#333333">
+			<path
+   d="M234.667,170.667c-35.307,0-64,28.693-64,64s28.693,64,64,64s64-28.693,64-64S269.973,170.667,234.667,170.667z"
+   id="path2"
+   style="fill:#333333" />
+			<path
+   d="M234.667,74.667C128,74.667,36.907,141.013,0,234.667c36.907,93.653,128,160,234.667,160     c106.773,0,197.76-66.347,234.667-160C432.427,141.013,341.44,74.667,234.667,74.667z M234.667,341.333     c-58.88,0-106.667-47.787-106.667-106.667S175.787,128,234.667,128s106.667,47.787,106.667,106.667     S293.547,341.333,234.667,341.333z"
+   id="path4"
+   style="fill:#333333" />
+		</g>
+	</g>
+</g>
+<g
+   id="g12">
+</g>
+<g
+   id="g14">
+</g>
+<g
+   id="g16">
+</g>
+<g
+   id="g18">
+</g>
+<g
+   id="g20">
+</g>
+<g
+   id="g22">
+</g>
+<g
+   id="g24">
+</g>
+<g
+   id="g26">
+</g>
+<g
+   id="g28">
+</g>
+<g
+   id="g30">
+</g>
+<g
+   id="g32">
+</g>
+<g
+   id="g34">
+</g>
+<g
+   id="g36">
+</g>
+<g
+   id="g38">
+</g>
+<g
+   id="g40">
+</g>
+</svg>

--- a/comictaggerlib/graphics/hidden.svg
+++ b/comictaggerlib/graphics/hidden.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Capa_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 469.44 469.44"
+   style="enable-background:new 0 0 469.44 469.44;"
+   xml:space="preserve"
+   sodipodi:docname="hidden.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs47" /><sodipodi:namedview
+   id="namedview45"
+   pagecolor="#505050"
+   bordercolor="#eeeeee"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#505050"
+   showgrid="false"
+   inkscape:zoom="2.187713"
+   inkscape:cx="234.72"
+   inkscape:cy="234.72"
+   inkscape:window-width="2560"
+   inkscape:window-height="1361"
+   inkscape:window-x="0"
+   inkscape:window-y="42"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Capa_1" />
+<g
+   id="g12"
+   style="fill:#333333">
+	<g
+   id="g10"
+   style="fill:#333333">
+		<g
+   id="g8"
+   style="fill:#333333">
+			<path
+   d="M231.147,160.373l67.2,67.2l0.32-3.52c0-35.307-28.693-64-64-64L231.147,160.373z"
+   id="path2"
+   style="fill:#333333" />
+			<path
+   d="M234.667,117.387c58.88,0,106.667,47.787,106.667,106.667c0,13.76-2.773,26.88-7.573,38.933l62.4,62.4     c32.213-26.88,57.6-61.653,73.28-101.333c-37.013-93.653-128-160-234.773-160c-29.867,0-58.453,5.333-85.013,14.933l46.08,45.973     C207.787,120.267,220.907,117.387,234.667,117.387z"
+   id="path4"
+   style="fill:#333333" />
+			<path
+   d="M21.333,59.253l48.64,48.64l9.707,9.707C44.48,145.12,16.64,181.707,0,224.053c36.907,93.653,128,160,234.667,160     c33.067,0,64.64-6.4,93.547-18.027l9.067,9.067l62.187,62.293l27.2-27.093L48.533,32.053L21.333,59.253z M139.307,177.12     l32.96,32.96c-0.96,4.587-1.6,9.173-1.6,13.973c0,35.307,28.693,64,64,64c4.8,0,9.387-0.64,13.867-1.6l32.96,32.96     c-14.187,7.04-29.973,11.307-46.827,11.307C175.787,330.72,128,282.933,128,224.053C128,207.2,132.267,191.413,139.307,177.12z"
+   id="path6"
+   style="fill:#333333" />
+		</g>
+	</g>
+</g>
+<g
+   id="g14">
+</g>
+<g
+   id="g16">
+</g>
+<g
+   id="g18">
+</g>
+<g
+   id="g20">
+</g>
+<g
+   id="g22">
+</g>
+<g
+   id="g24">
+</g>
+<g
+   id="g26">
+</g>
+<g
+   id="g28">
+</g>
+<g
+   id="g30">
+</g>
+<g
+   id="g32">
+</g>
+<g
+   id="g34">
+</g>
+<g
+   id="g36">
+</g>
+<g
+   id="g38">
+</g>
+<g
+   id="g40">
+</g>
+<g
+   id="g42">
+</g>
+</svg>

--- a/comictaggerlib/ui/talkeruigenerator.py
+++ b/comictaggerlib/ui/talkeruigenerator.py
@@ -40,6 +40,14 @@ def generate_api_widgets(
         else:
             QtWidgets.QMessageBox.warning(None, "API Test Failed", check_text)
 
+    def show_key(le_key: QtWidgets.QLineEdit) -> None:
+        current_state = le_key.echoMode()
+
+        if current_state == 0:
+            le_key.setEchoMode(QtWidgets.QLineEdit.EchoMode.PasswordEchoOnEdit)
+        else:
+            le_key.setEchoMode(QtWidgets.QLineEdit.EchoMode.Normal)
+
     # get the actual config objects in case they have overwritten the default
     talker_key = config[1][f"talker_{talker_id}"][1][f"{talker_id}_key"]
     talker_url = config[1][f"talker_{talker_id}"][1][f"{talker_id}_url"]
@@ -50,8 +58,9 @@ def generate_api_widgets(
     # only file settings are saved
     if talker_key.file:
         # record the current row so we know where to add the button
-        btn_test_row = layout.rowCount()
+        btn_show_key = layout.rowCount()
         le_key = generate_textbox(talker_key, layout)
+        le_key.setEchoMode(QtWidgets.QLineEdit.EchoMode.PasswordEchoOnEdit)
         # To enable setting and getting
         sources["tabs"][talker_id].widgets[f"talker_{talker_id}_{talker_id}_key"] = le_key
 
@@ -63,6 +72,12 @@ def generate_api_widgets(
         le_url = generate_textbox(talker_url, layout)
         # To enable setting and getting
         sources["tabs"][talker_id].widgets[f"talker_{talker_id}_{talker_id}_url"] = le_url
+
+    # The key button row was recorded so we add the show/hide button
+    if btn_show_key is not None:
+        btn_show = QtWidgets.QPushButton("Show/Hide")
+        layout.addWidget(btn_show, btn_show_key, 2)
+        btn_show.clicked.connect(partial(show_key, le_key=le_key))
 
     # The button row was recorded so we add it
     if btn_test_row is not None:

--- a/comictaggerlib/ui/talkeruigenerator.py
+++ b/comictaggerlib/ui/talkeruigenerator.py
@@ -19,6 +19,42 @@ class TalkerTab(NamedTuple):
     widgets: dict[str, QtWidgets.QWidget]
 
 
+class PasswordEdit(QtWidgets.QLineEdit):
+    """
+    Password LineEdit with icons to show/hide password entries.
+    Taken from https://github.com/pythonguis/python-qtwidgets/tree/master/qtwidgets
+    Based on this example https://kushaldas.in/posts/creating-password-input-widget-in-pyqt.html by Kushal Das.
+    """
+
+    def __init__(self, show_visibility=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.visibleIcon = QtGui.QIcon(str(graphics_path / "eye.svg"))
+        self.hiddenIcon = QtGui.QIcon(str(graphics_path / "hidden.svg"))
+
+        self.setEchoMode(QtWidgets.QLineEdit.Password)
+
+        if show_visibility:
+            # Add the password hide/shown toggle at the end of the edit box.
+            self.togglepasswordAction = self.addAction(self.visibleIcon, QtWidgets.QLineEdit.TrailingPosition)
+            self.togglepasswordAction.setToolTip("Show password")
+            self.togglepasswordAction.triggered.connect(self.on_toggle_password_Action)
+
+        self.password_shown = False
+
+    def on_toggle_password_Action(self):
+        if not self.password_shown:
+            self.setEchoMode(QtWidgets.QLineEdit.Normal)
+            self.password_shown = True
+            self.togglepasswordAction.setIcon(self.hiddenIcon)
+            self.togglepasswordAction.setToolTip("Hide password")
+        else:
+            self.setEchoMode(QtWidgets.QLineEdit.Password)
+            self.password_shown = False
+            self.togglepasswordAction.setIcon(self.visibleIcon)
+            self.togglepasswordAction.setToolTip("Show password")
+
+
 def generate_api_widgets(
     talker_id: str,
     sources: dict[str, QtWidgets.QWidget],
@@ -121,39 +157,6 @@ def generate_textbox(option: settngs.Setting, layout: QtWidgets.QGridLayout) -> 
 
 
 def generate_password_textbox(option: settngs.Setting, layout: QtWidgets.QGridLayout) -> QtWidgets.QLineEdit:
-    class PasswordEdit(QtWidgets.QLineEdit):
-        """
-        Password LineEdit with icons to show/hide password entries.
-        Taken from https://github.com/pythonguis/python-qtwidgets/tree/master/qtwidgets
-        Based on this example https://kushaldas.in/posts/creating-password-input-widget-in-pyqt.html by Kushal Das.
-        """
-
-        def __init__(self, show_visibility=True, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-            self.visibleIcon = QtGui.QIcon(str(graphics_path / "eye.svg"))
-            self.hiddenIcon = QtGui.QIcon(str(graphics_path / "hidden.svg"))
-
-            self.setEchoMode(QtWidgets.QLineEdit.Password)
-
-            if show_visibility:
-                # Add the password hide/shown toggle at the end of the edit box.
-                self.togglepasswordAction = self.addAction(self.visibleIcon, QtWidgets.QLineEdit.TrailingPosition)
-                self.togglepasswordAction.setToolTip("Show/Hide")
-                self.togglepasswordAction.triggered.connect(self.on_toggle_password_Action)
-
-            self.password_shown = False
-
-        def on_toggle_password_Action(self):
-            if not self.password_shown:
-                self.setEchoMode(QtWidgets.QLineEdit.Normal)
-                self.password_shown = True
-                self.togglepasswordAction.setIcon(self.hiddenIcon)
-            else:
-                self.setEchoMode(QtWidgets.QLineEdit.Password)
-                self.password_shown = False
-                self.togglepasswordAction.setIcon(self.visibleIcon)
-
     row = layout.rowCount()
     lbl = QtWidgets.QLabel(option.display_name)
     lbl.setToolTip(option.help)


### PR DESCRIPTION
I did wonder about renaming "{talker}-key" to "{talker}-token" to try and cover key/token/password. display_name and help can be altered so probably not needed. The only place it may be confusing a little is on the command line:

```
talker_metron:
  --metron-key METRON_KEY
                        Use the given Metron API password. (default: )
```
