### PR TITLE
Add option to presume the issue number as one

### DIFF
--- a/comictaggerlib/ctsettings/file.py
+++ b/comictaggerlib/ctsettings/file.py
@@ -83,6 +83,12 @@ def identifier(parser: settngs.Manager) -> None:
         action=argparse.BooleanOptionalAction,
         help="Clears all existing metadata when applying metadata from comic source",
     )
+    parser.add_setting(
+        "--presume-issue-one",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Presume issue 1 if no issue number is found",
+    )
 
 
 def dialog(parser: settngs.Manager) -> None:

--- a/comictaggerlib/settingswindow.py
+++ b/comictaggerlib/settingswindow.py
@@ -322,6 +322,7 @@ class SettingsWindow(QtWidgets.QDialog):
         self.cbxUseFilter.setChecked(self.config[0].identifier_always_use_publisher_filter)
         self.cbxSortByYear.setChecked(self.config[0].identifier_sort_series_by_year)
         self.cbxExactMatches.setChecked(self.config[0].identifier_exact_series_matches_first)
+        self.cbxPresumeIssueOne.setChecked(self.config[0].identifier_presume_issue_one)
 
         self.cbxAssumeLoneCreditIsPrimary.setChecked(self.config[0].cbl_assume_lone_credit_is_primary)
         self.cbxCopyCharactersToTags.setChecked(self.config[0].cbl_copy_characters_to_tags)
@@ -436,6 +437,7 @@ class SettingsWindow(QtWidgets.QDialog):
         self.config[0].identifier_always_use_publisher_filter = self.cbxUseFilter.isChecked()
         self.config[0].identifier_sort_series_by_year = self.cbxSortByYear.isChecked()
         self.config[0].identifier_exact_series_matches_first = self.cbxExactMatches.isChecked()
+        self.config[0].identifier_presume_issue_one = self.cbxPresumeIssueOne.isChecked()
 
         self.config[0].cbl_assume_lone_credit_is_primary = self.cbxAssumeLoneCreditIsPrimary.isChecked()
         self.config[0].cbl_copy_characters_to_tags = self.cbxCopyCharactersToTags.isChecked()

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1014,10 +1014,13 @@ class TaggerWindow(QtWidgets.QMainWindow):
     def query_online(self, autoselect: bool = False, literal: bool = False) -> None:
         issue_number = str(self.leIssueNum.text()).strip()
 
-        # Only need this check is the source has issue level data.
         if autoselect and issue_number == "":
             QtWidgets.QMessageBox.information(
-                self, "Automatic Identify Search", "Can't auto-identify without an issue number (yet!)"
+                self,
+                "Automatic Identify Search",
+                "Can't auto-identify without an issue number. Select 'Presume issue "
+                "1 if no issue provided' in the 'Searching' settings to "
+                "automatically apply the issue number as 1.",
             )
             return
 
@@ -2070,6 +2073,8 @@ class TaggerWindow(QtWidgets.QMainWindow):
         self.comic_archive = comic_archive
         try:
             self.metadata = self.comic_archive.read_metadata(self.load_data_style)
+            if not self.metadata.issue and self.config[0].identifier_presume_issue_one:
+                self.metadata.issue = "1"
         except Exception as e:
             logger.error("Failed to load metadata for %s: %s", self.comic_archive.path, e)
             self.exception(f"Failed to load metadata for {self.comic_archive.path}:\n\n{e}")

--- a/comictaggerlib/ui/settingswindow.ui
+++ b/comictaggerlib/ui/settingswindow.ui
@@ -28,7 +28,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="tGeneral">
         <attribute name="title">
@@ -136,14 +136,7 @@
          <string>Searching</string>
         </attribute>
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="3" column="0">
-          <widget class="Line" name="line_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
+         <item row="7" column="0">
           <layout class="QFormLayout" name="formLayout_2">
            <property name="fieldGrowthPolicy">
             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -242,20 +235,34 @@
            </item>
           </layout>
          </item>
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="cbxSortByYear">
+           <property name="text">
+            <string>Initially sort Series search results by Starting Year instead of No. Issues</string>
+           </property>
+          </widget>
+         </item>
          <item row="4" column="0">
+          <widget class="Line" name="line_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
           <widget class="QLabel" name="label_5">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;These settings are for the automatic issue identifier which searches online for matches. &lt;/p&gt;&lt;p&gt;Hover the mouse over an entry field for more info.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="Line" name="line_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -266,17 +273,20 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="cbxSortByYear">
-           <property name="text">
-            <string>Initially sort Series search results by Starting Year instead of No. Issues</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="0">
           <widget class="QCheckBox" name="cbxClearFormBeforePopulating">
            <property name="text">
             <string>Clear Form Before Importing Comic Vine data</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="cbxPresumeIssueOne">
+           <property name="toolTip">
+            <string>If no issue number is found Comic Tagger will add '1' as the issue number when the archive is loaded</string>
+           </property>
+           <property name="text">
+            <string>Presume issue 1 if no issue provided</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This seems like the simplest solution to the missing issue number problem. If there is no issue number and the option is selected (false by default) then when the archive is loaded, the issue number "1" is added.