### PR TITLE
Disable issues related buttons with series only talkers. GUI only.

### DIFF
--- a/comictaggerlib/seriesselectionwindow.py
+++ b/comictaggerlib/seriesselectionwindow.py
@@ -192,8 +192,14 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
 
         self.btnRequery.setEnabled(enabled)
 
-        self.btnIssues.setEnabled(enabled)
-        self.btnAutoSelect.setEnabled(enabled)
+        if self.talker.has_issue_level_data:
+            self.btnIssues.setEnabled(enabled)
+            self.btnAutoSelect.setEnabled(enabled)
+        else:
+            self.btnIssues.setEnabled(False)
+            self.btnIssues.setToolTip("Unsupported by " + self.talker.name)
+            self.btnAutoSelect.setEnabled(False)
+            self.btnAutoSelect.setToolTip("Unsupported by " + self.talker.name)
 
         self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).setEnabled(enabled)
 
@@ -517,7 +523,11 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
         self.auto_select()
 
     def cell_double_clicked(self, r: int, c: int) -> None:
-        self.show_issues()
+        if self.talker.has_issue_level_data:
+            self.show_issues()
+        else:
+            # Pass back to have taggerwindow get full series data
+            self.accept()
 
     def current_item_changed(self, curr: QtCore.QModelIndex | None, prev: QtCore.QModelIndex | None) -> None:
         if curr is None:

--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -111,6 +111,7 @@ class ComicTalker:
     website: str = "https://example.com"
     logo_url: str = f"{website}/logo.png"
     attribution: str = f"Metadata provided by <a href='{website}'>{name}</a>"
+    has_issue_level_data: bool = True
 
     def __init__(self, version: str, cache_folder: pathlib.Path) -> None:
         self.cache_folder = cache_folder


### PR DESCRIPTION
This allows the GUI to disable "auto-identify" and "show issues" buttons. I've put an extra property on the talker `has_issue_level_data` which defaults to `True`. With them disabled, double clicking the series is the same as "okay" and will tag with the series data.

No `issueidentifer` changes needed.

Below is a video with it on and off using PR #437.

![CT_no_issues](https://github.com/comictagger/comictagger/assets/1141189/1d170570-0cc4-4482-874e-90fa1f2bdbfa)
Buttons disabled

![CT_issues](https://github.com/comictagger/comictagger/assets/1141189/70d3d528-a20a-43b6-b0e6-216bdc0db577)
Duplicating series data into issue list