### PR TITLE
Replace instances of Comic Vine to use the talker's name

### DIFF
--- a/comictaggerlib/cli.py
+++ b/comictaggerlib/cli.py
@@ -118,7 +118,7 @@ class CLI:
                     md = ct_md
                 else:
                     notes = (
-                        f"Tagged with ComicTagger {ctversion.version} using info from Comic Vine on"
+                        f"Tagged with ComicTagger {ctversion.version} using info from {self.current_talker().name} on"
                         f" {datetime.now():%Y-%m-%d %H:%M:%S}.  [Issue ID {ct_md.issue_id}]"
                     )
                     md.overlay(ct_md.replace(notes=utils.combine_notes(md.notes, notes, "Tagged with ComicTagger")))
@@ -433,7 +433,7 @@ class CLI:
                 md = GenericMetadata()
 
             notes = (
-                f"Tagged with ComicTagger {ctversion.version} using info from Comic Vine on"
+                f"Tagged with ComicTagger {ctversion.version} using info from {self.current_talker().name} on"
                 f" {datetime.now():%Y-%m-%d %H:%M:%S}.  [Issue ID {ct_md.issue_id}]"
             )
             md.overlay(ct_md.replace(notes=utils.combine_notes(md.notes, notes, "Tagged with ComicTagger")))

--- a/comictaggerlib/coverimagewidget.py
+++ b/comictaggerlib/coverimagewidget.py
@@ -1,6 +1,6 @@
 """A PyQt5 widget to display cover images
 
-Display cover images from either a local archive, or from Comic Vine.
+Display cover images from either a local archive, or from comic source.
 TODO: This should be re-factored using subclasses!
 """
 #

--- a/comictaggerlib/coverimagewidget.py
+++ b/comictaggerlib/coverimagewidget.py
@@ -1,6 +1,6 @@
 """A PyQt5 widget to display cover images
 
-Display cover images from either a local archive, or from comic source.
+Display cover images from either a local archive, or from comic source metadata.
 TODO: This should be re-factored using subclasses!
 """
 #

--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -296,7 +296,7 @@ class IssueIdentifier:
                 primary_img_url, blocking=True
             )
         except ImageFetcherException as e:
-            self.log_msg("Network issue while fetching cover image from Comic Vine. Aborting...")
+            self.log_msg(f"Network issue while fetching cover image from {self.talker.name}. Aborting...")
             raise IssueIdentifierNetworkError from e
 
         if self.cancel:
@@ -318,7 +318,7 @@ class IssueIdentifier:
                         alt_url, blocking=True
                     )
                 except ImageFetcherException as e:
-                    self.log_msg("Network issue while fetching alt. cover image from Comic Vine. Aborting...")
+                    self.log_msg(f"Network issue while fetching alt. cover image from {self.talker.name}. Aborting...")
                     raise IssueIdentifierNetworkError from e
 
                 if self.cancel:

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1780,7 +1780,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
                     md = ct_md
                 else:
                     notes = (
-                        f"Tagged with ComicTagger {ctversion.version} using info from Comic Vine on"
+                        f"Tagged with ComicTagger {ctversion.version} using info from {self.current_talker().name} on"
                         f" {datetime.now():%Y-%m-%d %H:%M:%S}.  [Issue ID {ct_md.issue_id}]"
                     )
                     md.overlay(ct_md.replace(notes=utils.combine_notes(md.notes, notes, "Tagged with ComicTagger")))

--- a/comictaggerlib/ui/settingswindow.ui
+++ b/comictaggerlib/ui/settingswindow.ui
@@ -276,7 +276,7 @@
          <item row="2" column="0">
           <widget class="QCheckBox" name="cbxClearFormBeforePopulating">
            <property name="text">
-            <string>Clear Form Before Importing Comic Vine data</string>
+            <string>Clear form before importing comic data</string>
            </property>
           </widget>
          </item>

--- a/comictaggerlib/ui/settingswindow.ui
+++ b/comictaggerlib/ui/settingswindow.ui
@@ -276,7 +276,7 @@
          <item row="2" column="0">
           <widget class="QCheckBox" name="cbxClearFormBeforePopulating">
            <property name="text">
-            <string>Clear form before importing comic data</string>
+            <string>Clear form before importing comic metadata</string>
            </property>
           </widget>
          </item>

--- a/comictalker/comiccacher.py
+++ b/comictalker/comiccacher.py
@@ -1,4 +1,4 @@
-"""A python class to manage caching of data from Comic Vine"""
+"""A python class to manage caching of data from comic sources"""
 #
 # Copyright 2012-2014 ComicTagger Authors
 #

--- a/comictalker/comiccacher.py
+++ b/comictalker/comiccacher.py
@@ -1,4 +1,4 @@
-"""A python class to manage caching of data from comic sources"""
+"""A python class to manage caching of metadata from comic sources"""
 #
 # Copyright 2012-2014 ComicTagger Authors
 #


### PR DESCRIPTION
Remove hard coded "Comic Vine" and use the current talker's name instead.