### PR TITLE
Change auto-identfy message

### DIFF
--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1017,7 +1017,10 @@ class TaggerWindow(QtWidgets.QMainWindow):
         # Only need this check is the source has issue level data.
         if autoselect and issue_number == "":
             QtWidgets.QMessageBox.information(
-                self, "Automatic Identify Search", "Can't auto-identify without an issue number (yet!)"
+                self,
+                "Automatic Identify Search",
+                "Can't auto-identify without an issue number. The auto-tag function has the 'If no issue number, "
+                'assume "1"\' option if desired.',
             )
             return
 

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1019,8 +1019,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.information(
                 self,
                 "Automatic Identify Search",
-                "Can't auto-identify without an issue number. The auto-tag function has the 'If no issue number, "
-                'assume "1"\' option if desired.',
+                "Can't auto-identify without an issue number. The auto-tag function has the 'If no issue number, assume \"1\"' option if desired.",
             )
             return
 


### PR DESCRIPTION
Point the user to the auto-tag `assume 1` if there is no issue number. It could be thought just by reading the previous message that there was no way to auto-tag without an issue number.