### PR TITLE
Add pyrate-limiter and apply CV suggested rate limit

### DIFF
--- a/comictaggerlib/autotagstartwindow.py
+++ b/comictaggerlib/autotagstartwindow.py
@@ -48,7 +48,6 @@ class AutoTagStartWindow(QtWidgets.QDialog):
         self.cbxAssumeIssueOne.setChecked(self.config.autotag_assume_1_if_no_issue_num)
         self.cbxIgnoreLeadingDigitsInFilename.setChecked(self.config.autotag_ignore_leading_numbers_in_filename)
         self.cbxRemoveAfterSuccess.setChecked(self.config.autotag_remove_archive_after_successful_match)
-        self.cbxWaitForRateLimit.setChecked(self.config.autotag_wait_and_retry_on_rate_limit)
         self.cbxAutoImprint.setChecked(self.config.identifier_auto_imprint)
 
         nlmt_tip = """<html>The <b>Name Match Ratio Threshold: Auto-Identify</b> is for eliminating automatic
@@ -73,7 +72,6 @@ class AutoTagStartWindow(QtWidgets.QDialog):
         self.assume_issue_one = False
         self.ignore_leading_digits_in_filename = False
         self.remove_after_success = False
-        self.wait_and_retry_on_rate_limit = False
         self.search_string = ""
         self.name_length_match_tolerance = self.config.identifier_series_match_search_thresh
         self.split_words = self.cbxSplitWords.isChecked()
@@ -91,7 +89,6 @@ class AutoTagStartWindow(QtWidgets.QDialog):
         self.ignore_leading_digits_in_filename = self.cbxIgnoreLeadingDigitsInFilename.isChecked()
         self.remove_after_success = self.cbxRemoveAfterSuccess.isChecked()
         self.name_length_match_tolerance = self.sbNameMatchSearchThresh.value()
-        self.wait_and_retry_on_rate_limit = self.cbxWaitForRateLimit.isChecked()
         self.split_words = self.cbxSplitWords.isChecked()
 
         # persist some settings
@@ -100,7 +97,6 @@ class AutoTagStartWindow(QtWidgets.QDialog):
         self.config.autotag_assume_1_if_no_issue_num = self.assume_issue_one
         self.config.autotag_ignore_leading_numbers_in_filename = self.ignore_leading_digits_in_filename
         self.config.autotag_remove_archive_after_successful_match = self.remove_after_success
-        self.config.autotag_wait_and_retry_on_rate_limit = self.wait_and_retry_on_rate_limit
 
         if self.cbxSpecifySearchString.isChecked():
             self.search_string = self.leSearchString.text()

--- a/comictaggerlib/ctsettings/file.py
+++ b/comictaggerlib/ctsettings/file.py
@@ -207,14 +207,6 @@ def autotag(parser: settngs.Manager) -> None:
         help="When searching ignore leading numbers in the filename",
     )
     parser.add_setting("remove_archive_after_successful_match", default=False, cmdline=False)
-    parser.add_setting(
-        "-w",
-        "--wait-on-rate-limit",
-        dest="wait_and_retry_on_rate_limit",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="When encountering a Comic Vine rate limit\nerror, wait and retry query.\n\n",
-    )
 
 
 def validate_file_settings(config: settngs.Config[ct_ns]) -> settngs.Config[ct_ns]:

--- a/comictaggerlib/ctsettings/settngs_namespace.py
+++ b/comictaggerlib/ctsettings/settngs_namespace.py
@@ -102,4 +102,3 @@ class settngs_namespace(settngs.TypedNS):
     autotag_assume_1_if_no_issue_num: bool
     autotag_ignore_leading_numbers_in_filename: bool
     autotag_remove_archive_after_successful_match: bool
-    autotag_wait_and_retry_on_rate_limit: bool

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -257,6 +257,10 @@ class TaggerWindow(QtWidgets.QMainWindow):
                 Also, be aware that writing tags to comic archives will change their file hashes,
                 which has implications with respect to other software packages.  It's best to
                 use ComicTagger on local copies of your comics.<br><br>
+                COMIC VINE NOTE: Using the default API key will serverly limit search and tagging
+                times. A personal API key will allow for a <b>5 times increase</b> in online search speed. See the
+                <a href='https://github.com/comictagger/comictagger/wiki/UserGuide#comic-vine'>Wiki page</a>
+                for more information.<br><br>
                 Have fun!
                 """,
             )

--- a/comictaggerlib/ui/autotagstartwindow.ui
+++ b/comictaggerlib/ui/autotagstartwindow.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>519</width>
-    <height>440</height>
+    <height>448</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,84 +26,19 @@
    <bool>false</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="4" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="6" column="0">
-      <widget class="QCheckBox" name="cbxAutoImprint">
-       <property name="toolTip">
-        <string>Checks the publisher against a list of imprints.</string>
-       </property>
-       <property name="text">
-        <string>Auto Imprint</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QCheckBox" name="cbxSpecifySearchString">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Specify series search string for all selected archives:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="cbxIgnoreLeadingDigitsInFilename">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Ignore leading (sequence) numbers in filename</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="cbxSaveOnLowConfidence">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Save on low confidence match</string>
-       </property>
-      </widget>
-     </item>
      <item row="10" column="0">
-      <widget class="QLineEdit" name="leSearchString">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
       <widget class="QLabel" name="label_3">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -116,7 +51,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="7" column="0">
       <widget class="QCheckBox" name="cbxSplitWords">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -126,19 +61,6 @@
        </property>
        <property name="text">
         <string>Split words in filenames (e.g. 'judgedredd' to 'judge dredd') (Experimental)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="cbxDontUseYear">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Don't use publication year in identification process</string>
        </property>
       </widget>
      </item>
@@ -155,7 +77,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="6" column="0">
       <widget class="QCheckBox" name="cbxRemoveMetadata">
        <property name="toolTip">
         <string>Removes existing metadata before applying retrieved metadata</string>
@@ -165,7 +87,66 @@
        </property>
       </widget>
      </item>
+     <item row="9" column="0">
+      <widget class="QLineEdit" name="leSearchString">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="cbxDontUseYear">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Don't use publication year in identification process</string>
+       </property>
+      </widget>
+     </item>
      <item row="5" column="0">
+      <widget class="QCheckBox" name="cbxAutoImprint">
+       <property name="toolTip">
+        <string>Checks the publisher against a list of imprints.</string>
+       </property>
+       <property name="text">
+        <string>Auto Imprint</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QCheckBox" name="cbxSpecifySearchString">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Specify series search string for all selected archives:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="cbxSaveOnLowConfidence">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Save on low confidence match</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
       <widget class="QCheckBox" name="cbxRemoveAfterSuccess">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -179,13 +160,19 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QCheckBox" name="cbxWaitForRateLimit">
+      <widget class="QCheckBox" name="cbxIgnoreLeadingDigitsInFilename">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>Wait and retry when Comic Vine rate limit is exceeded (experimental)</string>
+        <string>Ignore leading (sequence) numbers in filename</string>
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
+     <item row="11" column="0">
       <widget class="QSpinBox" name="sbNameMatchSearchThresh">
        <property name="maximumSize">
         <size>
@@ -225,13 +212,19 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/comictalker/talkers/comicvine.py
+++ b/comictalker/talkers/comicvine.py
@@ -457,7 +457,7 @@ class ComicVineTalker(ComicTalker):
                     time.sleep(1)
                     logger.debug(str(resp.status_code))
                     tries += 1
-                if resp.status_code == 429:
+                if resp.status_code == requests.status_codes.codes.TOO_MANY_REQUESTS:
                     logger.info(f"{self.name} rate limit encountered. Waiting for 10 seconds\n")
                     time.sleep(10)
                     limit_counter += 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     pathvalidate
     pillow>=9.1.0,<10
     pycountry
+    pyrate-limiter
     rapidfuzz>=2.12.0
     requests==2.*
     settngs==0.7.1


### PR DESCRIPTION
This add pyrate-limiter to the required deps.

I took the (very) old comment from the CV API [forum](https://comicvine.gamespot.com/forums/api-developers-2334/api-rate-limiting-1746419/) and set the rate limit to 1 every 2 seconds. I've left a simple check and 10 second wait as a fallback. Instead of waiting many multiple minutes which might make the (GUI) user think the program has hung, it provides a network error with a link where to check your API usage.