### PR TITLE
Fix auto-identify crash

### DIFF
--- a/comictaggerlib/seriesselectionwindow.py
+++ b/comictaggerlib/seriesselectionwindow.py
@@ -349,7 +349,7 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
             self.imageWidget.update_content()
 
     def select_by_id(self) -> None:
-        for r in range(self.twList.rows()):
+        for r in range(self.twList.rowCount()):
             if self.series_id == self.twList.item(r, 0).data(QtCore.Qt.ItemDataRole.UserRole):
                 self.twList.selectRow(r)
                 break


### PR DESCRIPTION
Using auto-identify produces the following crash:
```
Traceback (most recent call last):
  File "comictagger/comictaggerlib/seriesselectionwindow.py", line 329, in identify_complete
    self.select_by_id()
  File "comictagger/comictaggerlib/seriesselectionwindow.py", line 352, in select_by_id
    for r in range(self.twList.rows()):
AttributeError: 'QTableWidget' object has no attribute 'rows'
```