### PR TITLE
Update series and issue rows after calling for more information.

### DIFF
--- a/comictaggerlib/issueselectionwindow.py
+++ b/comictaggerlib/issueselectionwindow.py
@@ -160,31 +160,10 @@ class IssueSelectionWindow(QtWidgets.QDialog):
 
         for row, issue in enumerate(self.issue_list.values()):
             self.twList.insertRow(row)
+            for i in range(3):
+                self.twList.setItem(row, i, QtWidgets.QTableWidgetItem())
 
-            item_text = issue.issue or ""
-            item = IssueNumberTableWidgetItem(item_text)
-            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, issue.issue_id)
-            item.setData(QtCore.Qt.ItemDataRole.DisplayRole, item_text)
-            item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.twList.setItem(row, 0, item)
-
-            item_text = ""
-            if issue.year is not None:
-                item_text += f"-{issue.year:04}"
-            if issue.month is not None:
-                item_text += f"-{issue.month:02}"
-
-            qtw_item = QtWidgets.QTableWidgetItem(item_text.strip("-"))
-            qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.twList.setItem(row, 1, qtw_item)
-
-            item_text = issue.title or ""
-            qtw_item = QtWidgets.QTableWidgetItem(item_text)
-            qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.twList.setItem(row, 2, qtw_item)
+            self.update_row(row, issue)
 
             if IssueString(issue.issue).as_string().casefold() == IssueString(self.issue_number).as_string().casefold():
                 self.initial_id = issue.issue_id or ""
@@ -204,6 +183,31 @@ class IssueSelectionWindow(QtWidgets.QDialog):
             html = text
             widget.setHtml(html, QtCore.QUrl(self.talker.website))
 
+    def update_row(self, row: int, issue: GenericMetadata) -> None:
+        item_text = issue.issue or ""
+        item = self.twList.item(row, 0)
+        item.setText(item_text)
+        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, issue.issue_id)
+        item.setData(QtCore.Qt.ItemDataRole.DisplayRole, item_text)
+
+        item_text = ""
+        if issue.year is not None:
+            item_text += f"-{issue.year:04}"
+        if issue.month is not None:
+            item_text += f"-{issue.month:02}"
+
+        qtw_item = self.twList.item(row, 1)
+        qtw_item.setText(item_text.strip("-"))
+        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
+        item_text = issue.title or ""
+        qtw_item = self.twList.item(row, 2)
+        qtw_item.setText(item_text)
+        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
     def current_item_changed(self, curr: QtCore.QModelIndex | None, prev: QtCore.QModelIndex | None) -> None:
         if curr is None:
             return
@@ -215,7 +219,7 @@ class IssueSelectionWindow(QtWidgets.QDialog):
 
         # list selection was changed, update the issue cover
         issue = self.issue_list[self.issue_id]
-        if not (issue.issue and issue.year and issue.month and issue.cover_image):
+        if not (issue.issue and issue.year and issue.month and issue.cover_image and issue.title):
             QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
             try:
                 issue = self.talker.fetch_comic_data(issue_id=self.issue_id)
@@ -231,25 +235,4 @@ class IssueSelectionWindow(QtWidgets.QDialog):
             self.set_description(self.teDescription, issue.description)
 
         # Update current record information
-        item_text = issue.issue or ""
-        item = IssueNumberTableWidgetItem(item_text)
-        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-        item.setData(QtCore.Qt.ItemDataRole.DisplayRole, item_text)
-        self.twList.setItem(row, 0, item)
-
-        item_text = ""
-        if issue.year is not None:
-            item_text += f"-{issue.year:04}"
-        if issue.month is not None:
-            item_text += f"-{issue.month:02}"
-
-        qtw_item = QtWidgets.QTableWidgetItem(item_text.strip("-"))
-        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-        self.twList.setItem(row, 1, qtw_item)
-
-        item_text = issue.title or ""
-        qtw_item = QtWidgets.QTableWidgetItem(item_text)
-        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-        self.twList.setItem(row, 2, qtw_item)
+        self.update_row(row, issue)

--- a/comictaggerlib/issueselectionwindow.py
+++ b/comictaggerlib/issueselectionwindow.py
@@ -210,15 +210,46 @@ class IssueSelectionWindow(QtWidgets.QDialog):
         if prev is not None and prev.row() == curr.row():
             return
 
-        self.issue_id = self.twList.item(curr.row(), 0).data(QtCore.Qt.ItemDataRole.UserRole)
+        row = curr.row()
+        self.issue_id = self.twList.item(row, 0).data(QtCore.Qt.ItemDataRole.UserRole)
 
-        # list selection was changed, update the the issue cover
+        # list selection was changed, update the issue cover
         issue = self.issue_list[self.issue_id]
         if not (issue.issue and issue.year and issue.month and issue.cover_image):
-            issue = self.talker.fetch_comic_data(issue_id=self.issue_id)
+            QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
+            try:
+                issue = self.talker.fetch_comic_data(issue_id=self.issue_id)
+            except TalkerError:
+                pass
+        QtWidgets.QApplication.restoreOverrideCursor()
+
         self.issue_number = issue.issue or ""
         self.coverWidget.set_issue_details(self.issue_id, [issue.cover_image or "", *issue.alternate_images])
         if issue.description is None:
             self.set_description(self.teDescription, "")
         else:
             self.set_description(self.teDescription, issue.description)
+
+        # Update current record information
+        item_text = issue.issue or ""
+        item = IssueNumberTableWidgetItem(item_text)
+        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        item.setData(QtCore.Qt.ItemDataRole.DisplayRole, item_text)
+        self.twList.setItem(row, 0, item)
+
+        item_text = ""
+        if issue.year is not None:
+            item_text += f"-{issue.year:04}"
+        if issue.month is not None:
+            item_text += f"-{issue.month:02}"
+
+        qtw_item = QtWidgets.QTableWidgetItem(item_text.strip("-"))
+        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+        self.twList.setItem(row, 1, qtw_item)
+
+        item_text = issue.title or ""
+        qtw_item = QtWidgets.QTableWidgetItem(item_text)
+        qtw_item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        qtw_item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+        self.twList.setItem(row, 2, qtw_item)

--- a/comictaggerlib/seriesselectionwindow.py
+++ b/comictaggerlib/seriesselectionwindow.py
@@ -481,36 +481,10 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
 
         for row, series in enumerate(self.series_list.values()):
             self.twList.insertRow(row)
+            for i in range(4):
+                self.twList.setItem(row, i, QtWidgets.QTableWidgetItem())
 
-            item_text = series.name
-            item = QtWidgets.QTableWidgetItem(item_text)
-            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            item.setData(QtCore.Qt.ItemDataRole.UserRole, series.id)
-            item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.twList.setItem(row, 0, item)
-
-            if series.start_year is not None:
-                item_text = f"{series.start_year:04}"
-                item = QtWidgets.QTableWidgetItem(item_text)
-                item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-                item.setData(QtCore.Qt.ItemDataRole.DisplayRole, series.start_year)
-                item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-                self.twList.setItem(row, 1, item)
-
-            if series.count_of_issues is not None:
-                item_text = f"{series.count_of_issues:04}"
-                item = QtWidgets.QTableWidgetItem(item_text)
-                item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-                item.setData(QtCore.Qt.ItemDataRole.DisplayRole, series.count_of_issues)
-                item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-                self.twList.setItem(row, 2, item)
-
-            if series.publisher is not None:
-                item_text = series.publisher
-                item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-                item = QtWidgets.QTableWidgetItem(item_text)
-                item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
-                self.twList.setItem(row, 3, item)
+            self.update_row(row, series)
 
         self.twList.setSortingEnabled(True)
         self.twList.selectRow(0)
@@ -552,6 +526,34 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
             html = text
             widget.setHtml(html, QUrl(self.talker.website))
 
+    def update_row(self, row: int, series: ComicSeries) -> None:
+        item_text = series.name
+        item = self.twList.item(row, 0)
+        item.setText(item_text)
+        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, series.id)
+        item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
+        item_text = str(series.start_year)
+        item = self.twList.item(row, 1)
+        item.setText(item_text)
+        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
+        item_text = str(series.count_of_issues)
+        item = self.twList.item(row, 2)
+        item.setText(item_text)
+        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+        item.setData(QtCore.Qt.ItemDataRole.DisplayRole, series.count_of_issues)
+        item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
+        if series.publisher is not None:
+            item_text = series.publisher
+            item = self.twList.item(row, 3)
+            item.setText(item_text)
+            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
+            item.setFlags(QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled)
+
     def current_item_changed(self, curr: QtCore.QModelIndex | None, prev: QtCore.QModelIndex | None) -> None:
         if curr is None:
             return
@@ -586,29 +588,4 @@ class SeriesSelectionWindow(QtWidgets.QDialog):
         self.imageWidget.set_url(series.image_url)
 
         # Update current record information
-        row = curr.row()
-        item_text = series.name
-        item = QtWidgets.QTableWidgetItem(item_text)
-        item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-        item.setData(QtCore.Qt.ItemDataRole.UserRole, series.id)
-        self.twList.setItem(row, 0, item)
-
-        if series.start_year is not None:
-            item_text = f"{series.start_year:04}"
-            item = QtWidgets.QTableWidgetItem(item_text)
-            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            item.setData(QtCore.Qt.ItemDataRole.DisplayRole, series.start_year)
-            self.twList.setItem(row, 1, item)
-
-        if series.count_of_issues is not None:
-            item_text = f"{series.count_of_issues:04}"
-            item = QtWidgets.QTableWidgetItem(item_text)
-            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            item.setData(QtCore.Qt.ItemDataRole.DisplayRole, series.count_of_issues)
-            self.twList.setItem(row, 2, item)
-
-        if series.publisher is not None:
-            item_text = series.publisher
-            item.setData(QtCore.Qt.ItemDataRole.ToolTipRole, item_text)
-            item = QtWidgets.QTableWidgetItem(item_text)
-            self.twList.setItem(row, 3, item)
+        self.update_row(row, series)


### PR DESCRIPTION
I also changed the cursor to "busy" and added a `try` as there are situations where with a mix of using the cache and the API a talker error would cause a crash.

Closes #512