### PR TITLE
Remove genres from ComicSeries

### DIFF
--- a/comicapi/genericmetadata.py
+++ b/comicapi/genericmetadata.py
@@ -79,7 +79,6 @@ class ComicSeries:
     image_url: str
     publisher: str
     start_year: int | None
-    genres: list[str]
     format: str | None
 
     def copy(self) -> ComicSeries:

--- a/comictalker/talkers/comicvine.py
+++ b/comictalker/talkers/comicvine.py
@@ -489,7 +489,6 @@ class ComicVineTalker(ComicTalker):
             name=record["name"],
             publisher=pub_name,
             start_year=start_year,
-            genres=[],
             format=None,
         )
 

--- a/testing/comicdata.py
+++ b/testing/comicdata.py
@@ -14,7 +14,6 @@ search_results = [
         publisher="test",
         start_year=0,
         aliases=[],
-        genres=[],
         format=None,
     ),
     dict(
@@ -27,7 +26,6 @@ search_results = [
         publisher="test",
         start_year=0,
         aliases=[],
-        genres=[],
         format=None,
     ),
 ]

--- a/testing/comicvine.py
+++ b/testing/comicvine.py
@@ -166,7 +166,6 @@ comic_series_result = comicapi.genericmetadata.ComicSeries(
     image_url=cv_volume_result["results"]["image"]["super_url"],
     publisher=cv_volume_result["results"]["publisher"]["name"],
     start_year=int(cv_volume_result["results"]["start_year"]),
-    genres=[],
     format=None,
 )
 date = utils.parse_date_str(cv_issue_result["results"]["cover_date"])
@@ -203,7 +202,6 @@ cv_md = comicapi.genericmetadata.GenericMetadata(
     day=date[0],
     issue_count=cv_volume_result["results"]["count_of_issues"],
     volume=None,
-    genres=[],
     language=None,
     description=cv_issue_result["results"]["description"],
     volume_count=None,


### PR DESCRIPTION
The reason for its addition was to enable the filtering of genres from the cache, with the new cache system it's no longer required as the raw data is cached.