### PR TITLE
FIX: Hamming distance for empty URL

### DIFF
--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -286,9 +286,9 @@ class IssueIdentifier:
         # local_cover_hash_list is a list of pre-calculated hashes.
         # use_remote_alternates - indicates to use alternate covers from CV
 
-        # If there is no URL return 0
+        # If there is no URL return 100
         if not primary_img_url:
-            return Score(score=0, url="", hash=0)
+            return Score(score=100, url="", hash=0)
 
         try:
             url_image_data = ImageFetcher(self.config.Runtime_Options_config.user_cache_dir).fetch(


### PR DESCRIPTION
A `0` is a perfect match. Change to 100.