### PR TITLE
Add CT verion check against talker requirements

### DIFF
--- a/comictalker/__init__.py
+++ b/comictalker/__init__.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import sys
 
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, parse
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -33,14 +33,14 @@ def get_talkers(version: str, cache: pathlib.Path) -> dict[str, ComicTalker]:
                 logger.error("Talker ID must be the same as the entry point name")
                 continue
             try:
-                if version in SpecifierSet(obj.ct_req_spec, prereleases=True):
+                if parse(version) >= parse(obj.comictagger_min_ver):
                     talkers[talker.name] = obj
                 else:
                     logger.error(
-                        f"CT required version not met for talker: {talker.name} with specifier: {obj.ct_req_spec}"
+                        f"CT minimum required version not met for talker: {talker.name} with version: {obj.comictagger_min_ver}"
                     )
-            except InvalidSpecifier:
-                logger.error(f"Invalid specifier for talker: {talker.name} - specifier: {obj.ct_req_spec}")
+            except InvalidVersion:
+                logger.error(f"Invalid version number for talker: {talker.name} - version: {obj.comictagger_min_ver}")
 
         except Exception:
             logger.exception("Failed to load talker: %s", talker.name)

--- a/comictalker/__init__.py
+++ b/comictalker/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
 def get_talkers(version: str, cache: pathlib.Path) -> dict[str, ComicTalker]:
     """Returns all comic talker instances"""
     talkers: dict[str, ComicTalker] = {}
+    ct_version = parse(version)
 
     for talker in entry_points(group="comictagger.talker"):
         try:
@@ -33,7 +34,7 @@ def get_talkers(version: str, cache: pathlib.Path) -> dict[str, ComicTalker]:
                 logger.error("Talker ID must be the same as the entry point name")
                 continue
             try:
-                if parse(version) >= parse(obj.comictagger_min_ver):
+                if ct_version >= parse(obj.comictagger_min_ver):
                     talkers[talker.name] = obj
                 else:
                     logger.error(

--- a/comictalker/__init__.py
+++ b/comictalker/__init__.py
@@ -37,10 +37,15 @@ def get_talkers(version: str, cache: pathlib.Path) -> dict[str, ComicTalker]:
                     talkers[talker.name] = obj
                 else:
                     logger.error(
-                        f"CT minimum required version not met for talker: {talker.name} with version: {obj.comictagger_min_ver}"
+                        f"Minimum ComicTagger version required of {obj.comictagger_min_ver} for talker {talker.name} is not met, will NOT load talker"
                     )
             except InvalidVersion:
-                logger.error(f"Invalid version number for talker: {talker.name} - version: {obj.comictagger_min_ver}")
+                logger.warning(
+                    f"Invalid minimum required ComicTagger version number for talker: {talker.name} - version: {obj.comictagger_min_ver}, will load talker anyway"
+                )
+                # Attempt to use the talker anyway
+                # TODO flag this problem for later display to the user
+                talkers[talker.name] = obj
 
         except Exception:
             logger.exception("Failed to load talker: %s", talker.name)

--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -107,6 +107,7 @@ class ComicTalker:
 
     name: str = "Example"
     id: str = "example"
+    ct_req_spec: str = ">=1.6.0a7"  # The ComicTagger version required by the talker using PyPA version specifiers
     website: str = "https://example.com"
     logo_url: str = f"{website}/logo.png"
     attribution: str = f"Metadata provided by <a href='{website}'>{name}</a>"

--- a/comictalker/comictalker.py
+++ b/comictalker/comictalker.py
@@ -107,7 +107,7 @@ class ComicTalker:
 
     name: str = "Example"
     id: str = "example"
-    ct_req_spec: str = ">=1.6.0a7"  # The ComicTagger version required by the talker using PyPA version specifiers
+    comictagger_min_ver: str = "1.6.0a7"  # The ComicTagger minimum version required by the talker
     website: str = "https://example.com"
     logo_url: str = f"{website}/logo.png"
     attribution: str = f"Metadata provided by <a href='{website}'>{name}</a>"


### PR DESCRIPTION
I picked `>=1.6.0a7` as the default because that is when the lists were changed to sets etc.