### PR TITLE
Fix crash when using shortcut to set page type

### DIFF
--- a/comictaggerlib/pagelisteditor.py
+++ b/comictaggerlib/pagelisteditor.py
@@ -124,7 +124,7 @@ class PageListEditor(QtWidgets.QWidget):
         self.addAction(action_item)
 
     def select_page_type_item(self, idx: int) -> None:
-        if self.cbPageType.isEnabled() and self.listWidget.rowCount() > 0:
+        if self.cbPageType.isEnabled() and self.listWidget.count() > 0:
             self.cbPageType.setCurrentIndex(idx)
             self.change_page_type(idx)
 


### PR DESCRIPTION
QListWidget has no rowCount() method, it has count() instead.