### PR TITLE
Add button to autodetect double pages

### DIFF
--- a/comicapi/comicarchive.py
+++ b/comicapi/comicarchive.py
@@ -21,7 +21,7 @@ import pathlib
 import shutil
 import sys
 import traceback
-from typing import cast
+from typing import Tuple, cast
 
 from comicapi import utils
 from comicapi.archivers import Archiver, UnknownArchiver, ZipArchiver
@@ -515,6 +515,31 @@ class ComicArchive:
                         break
 
         return self._has_comet
+
+    def get_image_dimensions(self, image_idx: int) -> Tuple[int, int, int]:
+        if not self.pil_available:
+            return -1, -1, -1
+
+        try:
+            from PIL import Image
+        except ImportError:
+            self.pil_available = False
+            return -1, -1, -1
+
+        data = self.get_page(image_idx)
+        if data:
+            try:
+                if isinstance(data, bytes):
+                    im = Image.open(io.BytesIO(data))
+                else:
+                    im = Image.open(io.StringIO(data))
+                w, h = im.size
+
+                return w, h, len(data)
+            except Exception:
+                return -1, -1, -1
+
+        return -1, -1, -1
 
     def apply_archive_info_to_metadata(self, md: GenericMetadata, calc_page_sizes: bool = False) -> None:
         md.page_count = self.get_number_of_pages()

--- a/comicapi/comicarchive.py
+++ b/comicapi/comicarchive.py
@@ -516,7 +516,7 @@ class ComicArchive:
 
         return self._has_comet
 
-    def get_image_dimensions(self, image_idx: int) -> Tuple[int, int, int]:
+    def get_image_dimensions(self, image_idx: int) -> tuple[int, int, int]:
         if not self.pil_available:
             return -1, -1, -1
 

--- a/comictaggerlib/ui/pagelisteditor.ui
+++ b/comictaggerlib/ui/pagelisteditor.ui
@@ -108,6 +108,13 @@
          </property>
         </widget>
        </item>
+       <item row="0" column="3">
+        <widget class="QPushButton" name="btnAutoDouble">
+         <property name="text">
+          <string>Auto-Detect Double Pages</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
This adds a new feature, a new button to the page list, "Auto-Detect Double Pages".

Clicking that button iterates over all pages and decides if it's a double page or not and marks it as such. The "heuristic" is dead simple: if the page is least as wide as tall, it's a double page, otherwise it isn't. I don't know if there should be some smarter detection there for uncommon page formats or what-have-you, but for the standard comics in US Letter or A4 size, this generally works: a normal page is in portrait orientation and two portrait oriented pages side-by-side are wider than tall.

If the archive's big, if there's a lot of pages and the sizes haven't been calculated before, the process may take a bit. Maybe there should be a "Working..." dialog box or something there, then, but no idea.