### PR TITLE
Add support for saving multiple metadata styles in the GUI

### DIFF
--- a/comictaggerlib/autotagmatchwindow.py
+++ b/comictaggerlib/autotagmatchwindow.py
@@ -251,6 +251,11 @@ class AutoTagMatchWindow(QtWidgets.QDialog):
             success = ca.write_metadata(md, style)
             QtWidgets.QApplication.restoreOverrideCursor()
             if not success:
-                QtWidgets.QMessageBox.warning(self, "Write Error", "Saving the tags to the archive seemed to fail!")
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Write Error",
+                    f"Saving {metadata_styles[style].name()} the tags to the archive seemed to fail!",
+                )
+                break
 
         ca.load_cache(list(metadata_styles))

--- a/comictaggerlib/autotagmatchwindow.py
+++ b/comictaggerlib/autotagmatchwindow.py
@@ -39,7 +39,7 @@ class AutoTagMatchWindow(QtWidgets.QDialog):
         self,
         parent: QtWidgets.QWidget,
         match_set_list: list[Result],
-        style: str,
+        styles: list[str],
         fetch_func: Callable[[IssueResult], GenericMetadata],
         config: ct_ns,
         talker: ComicTalker,
@@ -81,7 +81,7 @@ class AutoTagMatchWindow(QtWidgets.QDialog):
         self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).setText("Accept and Write Tags")
 
         self.match_set_list = match_set_list
-        self._style = style
+        self._styles = styles
         self.fetch_func = fetch_func
 
         self.current_match_set_idx = 0
@@ -230,7 +230,7 @@ class AutoTagMatchWindow(QtWidgets.QDialog):
         match = self.current_match()
         ca = ComicArchive(self.current_match_set.original_path)
 
-        md = ca.read_metadata(self._style)
+        md = ca.read_metadata(self.config.internal__load_data_style)
         if md.is_empty:
             md = ca.metadata_from_filename(
                 self.config.Filename_Parsing__complicated_parser,
@@ -247,10 +247,10 @@ class AutoTagMatchWindow(QtWidgets.QDialog):
 
         QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
         md.overlay(ct_md)
-        success = ca.write_metadata(md, self._style)
+        for style in self._styles:
+            success = ca.write_metadata(md, style)
+            QtWidgets.QApplication.restoreOverrideCursor()
+            if not success:
+                QtWidgets.QMessageBox.warning(self, "Write Error", "Saving the tags to the archive seemed to fail!")
+
         ca.load_cache(list(metadata_styles))
-
-        QtWidgets.QApplication.restoreOverrideCursor()
-
-        if not success:
-            QtWidgets.QMessageBox.warning(self, "Write Error", "Saving the tags to the archive seemed to fail!")

--- a/comictaggerlib/ctsettings/file.py
+++ b/comictaggerlib/ctsettings/file.py
@@ -18,6 +18,7 @@ def general(parser: settngs.Manager) -> None:
         action=argparse.BooleanOptionalAction,
         help="Disable the ComicRack metadata type",
     )
+    parser.add_setting("use_short_metadata_names", default=False, action=argparse.BooleanOptionalAction, cmdline=False)
 
 
 def internal(parser: settngs.Manager) -> None:

--- a/comictaggerlib/ctsettings/file.py
+++ b/comictaggerlib/ctsettings/file.py
@@ -23,7 +23,7 @@ def general(parser: settngs.Manager) -> None:
 def internal(parser: settngs.Manager) -> None:
     # automatic settings
     parser.add_setting("install_id", default=uuid.uuid4().hex, cmdline=False)
-    parser.add_setting("save_data_style", default="cbi", cmdline=False)
+    parser.add_setting("save_data_style", default=["cbi"], cmdline=False)
     parser.add_setting("load_data_style", default="cbi", cmdline=False)
     parser.add_setting("last_opened_folder", default="", cmdline=False)
     parser.add_setting("window_width", default=0, cmdline=False)
@@ -255,6 +255,11 @@ def parse_filter(config: settngs.Config[ct_ns]) -> settngs.Config[ct_ns]:
 
 def validate_file_settings(config: settngs.Config[ct_ns]) -> settngs.Config[ct_ns]:
     config = parse_filter(config)
+
+    # TODO Remove this conversion check at a later date
+    if isinstance(config[0].internal__save_data_style, str):
+        config[0].internal__save_data_style = [config[0].internal__save_data_style]
+
     if config[0].Filename_Parsing__protofolius_issue_number_scheme:
         config[0].Filename_Parsing__allow_issue_start_with_letter = True
 

--- a/comictaggerlib/ctsettings/settngs_namespace.py
+++ b/comictaggerlib/ctsettings/settngs_namespace.py
@@ -37,7 +37,7 @@ class settngs_namespace(settngs.TypedNS):
     Runtime_Options__files: list[str]
 
     internal__install_id: str
-    internal__save_data_style: str
+    internal__save_data_style: list[str]
     internal__load_data_style: str
     internal__last_opened_folder: str
     internal__window_width: int

--- a/comictaggerlib/ctsettings/settngs_namespace.py
+++ b/comictaggerlib/ctsettings/settngs_namespace.py
@@ -97,6 +97,7 @@ class settngs_namespace(settngs.TypedNS):
 
     General__check_for_new_version: bool
     General__disable_cr: bool
+    General__use_short_metadata_names: bool
 
     Dialog_Flags__show_disclaimer: bool
     Dialog_Flags__dont_notify_about_this_version: str

--- a/comictaggerlib/pagelisteditor.py
+++ b/comictaggerlib/pagelisteditor.py
@@ -115,7 +115,7 @@ class PageListEditor(QtWidgets.QWidget):
 
         self.comic_archive: ComicArchive | None = None
         self.pages_list: list[ImageMetadata] = []
-        self.data_style = ""
+        self.data_styles: list[str] = []
 
     def reset_page(self) -> None:
         self.pageWidget.clear()
@@ -326,7 +326,7 @@ class PageListEditor(QtWidgets.QWidget):
         self.comic_archive = comic_archive
         self.pages_list = pages_list
         if pages_list:
-            self.set_metadata_style(self.data_style)
+            self.set_metadata_style(self.data_styles)
         else:
             self.cbPageType.setEnabled(False)
             self.chkDoublePage.setEnabled(False)
@@ -370,11 +370,16 @@ class PageListEditor(QtWidgets.QWidget):
             self.first_front_page = self.get_first_front_cover()
             self.firstFrontCoverChanged.emit(self.first_front_page)
 
-    def set_metadata_style(self, data_style: str) -> None:
+    def set_metadata_style(self, data_styles: list[str]) -> None:
         # depending on the current data style, certain fields are disabled
-        if data_style:
-            self.metadata_style = data_style
+        if data_styles:
+            styles = [metadata_styles[style] for style in data_styles]
+            enabled_widgets = []
+            for style in styles:
+                for attr in style.supported_attributes:
+                    enabled_widgets.append(attr)
 
-            enabled_widgets = metadata_styles[data_style].supported_attributes
+            self.data_styles = data_styles
+
             for metadata, widget in self.md_attributes.items():
                 enable_widget(widget, metadata in enabled_widgets)

--- a/comictaggerlib/pagelisteditor.py
+++ b/comictaggerlib/pagelisteditor.py
@@ -374,10 +374,9 @@ class PageListEditor(QtWidgets.QWidget):
         # depending on the current data style, certain fields are disabled
         if data_styles:
             styles = [metadata_styles[style] for style in data_styles]
-            enabled_widgets = []
+            enabled_widgets = set()
             for style in styles:
-                for attr in style.supported_attributes:
-                    enabled_widgets.append(attr)
+                enabled_widgets.update(style.supported_attributes)
 
             self.data_styles = data_styles
 

--- a/comictaggerlib/settingswindow.py
+++ b/comictaggerlib/settingswindow.py
@@ -376,6 +376,7 @@ class SettingsWindow(QtWidgets.QDialog):
         self.tePublisherFilter.setPlainText("\n".join(self.config[0].Issue_Identifier__publisher_filter))
 
         self.cbxCheckForNewVersion.setChecked(self.config[0].General__check_for_new_version)
+        self.cbxShortMetadataNames.setChecked(self.config[0].General__use_short_metadata_names)
 
         self.cbxComplicatedParser.setChecked(self.config[0].Filename_Parsing__complicated_parser)
         self.cbxRemoveC2C.setChecked(self.config[0].Filename_Parsing__remove_c2c)
@@ -492,6 +493,12 @@ class SettingsWindow(QtWidgets.QDialog):
             self.leIssueNumPadding.setText("0")
 
         self.config[0].General__check_for_new_version = self.cbxCheckForNewVersion.isChecked()
+
+        # Update metadata style names if required
+        if self.cbxShortMetadataNames.isChecked() != self.config[0].General__use_short_metadata_names:
+            self.config[0].General__use_short_metadata_names = self.cbxShortMetadataNames.isChecked()
+            self.parent().populate_style_names()
+            self.parent().adjust_save_style_combo()
 
         self.config[0].Issue_Identifier__series_match_identify_thresh = self.sbNameMatchIdentifyThresh.value()
         self.config[0].Issue_Identifier__series_match_search_thresh = self.sbNameMatchSearchThresh.value()

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1377,11 +1377,19 @@ class TaggerWindow(QtWidgets.QMainWindow):
             self.cbSaveDataStyle.setItemChecked(self.cbLoadDataStyle.findData(style), False)
         self.update_metadata_style_tweaks()
 
-    def populate_combo_boxes(self) -> None:
+    def populate_style_names(self) -> None:
+        # First clear all entries (called from settingswindow.py)
+        self.cbSaveDataStyle.clear()
         # Add the entries to the tag style combobox
         for style in metadata_styles.values():
             self.cbLoadDataStyle.addItem(style.name(), style.short_name)
-            self.cbSaveDataStyle.addItem(style.name(), style.short_name)
+            if self.config[0].General__use_short_metadata_names:
+                self.cbSaveDataStyle.addItem(style.short_name.upper(), style.short_name)
+            else:
+                self.cbSaveDataStyle.addItem(style.name(), style.short_name)
+
+    def populate_combo_boxes(self) -> None:
+        self.populate_style_names()
 
         self.adjust_load_style_combo()
         self.adjust_save_style_combo()

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -61,7 +61,6 @@ from comictaggerlib.resulttypes import Action, IssueResult, MatchStatus, OnlineM
 from comictaggerlib.seriesselectionwindow import SeriesSelectionWindow
 from comictaggerlib.settingswindow import SettingsWindow
 from comictaggerlib.ui import ui_path
-from comictaggerlib.ui.customwidgets import CheckableComboBox
 from comictaggerlib.ui.qtutils import center_window_on_parent, enable_widget, reduce_widget_font_size
 from comictaggerlib.versionchecker import VersionChecker
 from comictalker.comictalker import ComicTalker, TalkerError
@@ -226,19 +225,6 @@ class TaggerWindow(QtWidgets.QMainWindow):
             config[0].internal__load_data_style = list(metadata_styles.keys())[0]
         self.save_data_styles: list[str] = config[0].internal__save_data_style
         self.load_data_style: str = config[0].internal__load_data_style
-
-        # Add multiselect combobox
-        self.cbSaveDataStyle = CheckableComboBox()
-        self.cbSaveDataStyle.setToolTip("At least 1 save style is required")
-        # Add normal combobox for read style (TODO support multiple read styles)
-        self.cbLoadDataStyle = QtWidgets.QComboBox()
-
-        # Need to set minimum or source_style_formLayout will resize larger than 230px which will affect the
-        # file info box and cover image width underneath
-        self.cbLoadDataStyle.setMinimumWidth(100)
-        self.cbSaveDataStyle.setMinimumWidth(100)
-        self.source_style_formLayout.addRow("Read Style", self.cbLoadDataStyle)
-        self.source_style_formLayout.addRow("Modify Styles", self.cbSaveDataStyle)
 
         self.setAcceptDrops(True)
         self.view_tag_actions, self.remove_tag_actions = self.tag_actions()

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1544,8 +1544,8 @@ class TaggerWindow(QtWidgets.QMainWindow):
                                 failed_list.append(ca.path)
                                 # Abandon any further tag removals to prevent any greater damage to archive
                                 break
-                            ca.reset_cache()
-                            ca.load_cache(list(metadata_styles))
+                    ca.reset_cache()
+                    ca.load_cache(list(metadata_styles))
 
                 progdialog.hide()
                 QtCore.QCoreApplication.processEvents()
@@ -1623,6 +1623,8 @@ class TaggerWindow(QtWidgets.QMainWindow):
 
                     if ca.has_metadata(src_style) and ca.is_writable():
                         md = ca.read_metadata(src_style)
+                    else:
+                        continue
 
                     for style in dest_styles:
                         if ca.has_metadata(style):

--- a/comictaggerlib/ui/customwidgets.py
+++ b/comictaggerlib/ui/customwidgets.py
@@ -1,0 +1,113 @@
+"""Custom widgets"""
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt5 import QtGui, QtWidgets
+from PyQt5.QtCore import QEvent, QRect, Qt, pyqtSignal
+
+
+# Multiselect combobox from: https://gis.stackexchange.com/a/351152 (with custom changes)
+class CheckableComboBox(QtWidgets.QComboBox):
+    itemChecked = pyqtSignal(str, bool)
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        # Prevent popup from closing when clicking on an item
+        self.view().viewport().installEventFilter(self)
+
+        # Keeps track of when the combobox list is shown
+        self.justShown = False
+
+    def resizeEvent(self, event: Any) -> None:
+        # Recompute text to elide as needed
+        super().resizeEvent(event)
+        self._updateText()
+
+    def eventFilter(self, obj: Any, event: Any) -> bool:
+        # Allow events before the combobox list is shown
+        if obj == self.view().viewport():
+            # We record that the combobox list has been shown
+            if event.type() == QEvent.Show:
+                self.justShown = True
+            # We record that the combobox list has hidden,
+            # this will happen if the user does not make a selection
+            # but clicks outside of the combobox list or presses escape
+            if event.type() == QEvent.Hide:
+                self._updateText()
+                self.justShown = False
+            # QEvent.MouseButtonPress is inconsistent on activation because double clicks are a thing
+            if event.type() == QEvent.MouseButtonRelease:
+                # If self.justShown is true it means that they clicked on the combobox to change the checked items
+                # This is standard behavior (on macos) but I think it is surprising when it has a multiple select
+                if self.justShown:
+                    self.justShown = False
+                    return True
+
+                # Find the current index and item
+                index = self.view().indexAt(event.pos())
+                self.toggleItem(index.row())
+                return True
+        return False
+
+    def currentData(self) -> list[Any]:
+        # Return the list of all checked items data
+        res = []
+        for i in range(self.count()):
+            item = self.model().item(i)
+            if item.checkState() == Qt.Checked:
+                res.append(self.itemData(i))
+        return res
+
+    def addItem(self, text: str, data: Any = None) -> None:
+        super().addItem(text, data)
+        # Need to enable the checkboxes and require one checked item
+        # Expected that state of *all* checkboxes will be set ('adjust_save_style_combo' in taggerwindow.py)
+        if self.count() == 1:
+            self.model().item(0).setCheckState(Qt.CheckState.Checked)
+
+    def _updateText(self) -> None:
+        texts = []
+        for i in range(self.count()):
+            item = self.model().item(i)
+            if item.checkState() == Qt.Checked:
+                texts.append(item.text())
+        text = ", ".join(texts)
+
+        # Compute elided text (with "...")
+
+        # The QStyleOptionComboBox is needed for the call to subControlRect
+        so = QtWidgets.QStyleOptionComboBox()
+        # init with the current widget
+        so.initFrom(self)
+
+        # Ask the style for the size of the text field
+        rect = self.style().subControlRect(QtWidgets.QStyle.CC_ComboBox, so, QtWidgets.QStyle.SC_ComboBoxEditField)
+
+        # Compute the elided text
+        elidedText = self.fontMetrics().elidedText(text, Qt.ElideRight, rect.width())
+
+        # This CheckableComboBox does not use the index, so we clear it and set the placeholder text
+        self.setCurrentIndex(-1)
+        self.setPlaceholderText(elidedText)
+
+    def setItemChecked(self, index: Any, state: bool) -> None:
+        qt_state = Qt.Checked if state else Qt.Unchecked
+        item = self.model().item(index)
+        current = self.currentData()
+        # If we have at least one item checked emit itemChecked with the current check state and update text
+        # Require at least one item to be checked and provide a tooltip
+        if len(current) == 1 and not state and item.checkState() == Qt.Checked:
+            QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), self.toolTip(), self, QRect(), 3000)
+            return
+
+        if len(current) > 0:
+            item.setCheckState(qt_state)
+            self.itemChecked.emit(self.itemData(index), state)
+            self._updateText()
+
+    def toggleItem(self, index: int) -> None:
+        if self.model().item(index).checkState() == Qt.Checked:
+            self.setItemChecked(index, False)
+        else:
+            self.setItemChecked(index, True)

--- a/comictaggerlib/ui/customwidgets.py
+++ b/comictaggerlib/ui/customwidgets.py
@@ -1,4 +1,5 @@
 """Custom widgets"""
+
 from __future__ import annotations
 
 from typing import Any

--- a/comictaggerlib/ui/settingswindow.ui
+++ b/comictaggerlib/ui/settingswindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>702</width>
-    <height>559</height>
+    <width>703</width>
+    <height>574</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,7 +41,7 @@
             <string/>
            </property>
            <layout class="QGridLayout" name="gridLayout_4">
-            <item row="1" column="0">
+            <item row="2" column="0">
              <widget class="QPushButton" name="btnResetSettings">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -54,23 +54,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="lblDefaultSettings">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Revert to default settings</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
+            <item row="3" column="0">
              <widget class="QPushButton" name="btnClearCache">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -83,7 +67,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="3" column="1">
              <widget class="QLabel" name="label_2">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -99,10 +83,36 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="lblDefaultSettings">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Revert to default settings</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="0" colspan="2">
              <widget class="QCheckBox" name="cbxCheckForNewVersion">
               <property name="text">
                <string>Check for new version on startup</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="cbxShortMetadataNames">
+              <property name="toolTip">
+               <string>Use the short name for the metadata styles (CBI, CR, etc.)</string>
+              </property>
+              <property name="text">
+               <string>Use &quot;short&quot; names for metadata styles</string>
               </property>
              </widget>
             </item>
@@ -411,7 +421,7 @@
               <x>11</x>
               <y>21</y>
               <width>251</width>
-              <height>199</height>
+              <height>206</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_7">

--- a/comictaggerlib/ui/taggerwindow.ui
+++ b/comictaggerlib/ui/taggerwindow.ui
@@ -52,7 +52,7 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <layout class="QFormLayout" name="source_style_formLayout">
+           <layout class="QFormLayout" name="style_layout">
             <property name="fieldGrowthPolicy">
              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
             </property>
@@ -74,6 +74,26 @@
             </item>
             <item row="0" column="1">
              <widget class="QComboBox" name="cbx_sources"/>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="cbLoadDataStyle"/>
+            </item>
+            <item row="2" column="1">
+             <widget class="CheckableComboBox" name="cbSaveDataStyle"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lbl_read_style">
+              <property name="text">
+               <string>Read Style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lbl_modify_style">
+              <property name="text">
+               <string>Modify Styles</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -1441,6 +1461,13 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>CheckableComboBox</class>
+   <extends>QComboBox</extends>
+   <header>comictaggerlib.ui.customwidgets</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/comictaggerlib/ui/taggerwindow.ui
+++ b/comictaggerlib/ui/taggerwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1096</width>
-    <height>621</height>
+    <height>658</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -52,37 +52,23 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <layout class="QFormLayout" name="formLayout">
+           <layout class="QFormLayout" name="source_style_formLayout">
             <property name="fieldGrowthPolicy">
              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="formAlignment">
              <set>Qt::AlignHCenter|Qt::AlignTop</set>
             </property>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Read Style</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="cbLoadDataStyle"/>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="saveStyleLabel">
-              <property name="text">
-               <string>Modify Style</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="cbSaveDataStyle"/>
-            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="lbl_md_source">
               <property name="text">
-               <string>Metadata Source</string>
+               <string>Data Source</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
@@ -825,9 +811,6 @@
                      <property name="text">
                       <string>Primary</string>
                      </property>
-                     <property name="textAlignment">
-                      <set>AlignCenter</set>
-                     </property>
                     </column>
                     <column>
                      <property name="text">
@@ -1166,7 +1149,7 @@
      <x>0</x>
      <y>0</y>
      <width>1096</width>
-     <height>21</height>
+     <height>28</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuComicTagger">
@@ -1383,7 +1366,7 @@
   </action>
   <action name="actionRemoveAuto">
    <property name="text">
-    <string>Remove Current 'Modify' Tag Style</string>
+    <string>Remove Current 'Modify' Tag Style(s)</string>
    </property>
   </action>
   <action name="actionRename">


### PR DESCRIPTION
It may make more sense to put the `CheckableComboBox` in its own file in the `ui` dir?

I gave up with the style/theming and it seems a lot of hassle https://forum.qt.io/topic/113522/styling-qcombobox-s-lineedit

I presumed there is no point in allowing no write styles, so one is always required and the tooltip saying as much is displayed if it's tried. I thought this is probably the best place rather than say, checking on save etc.

A couple of places I changed reading of the current archive metadata from the write style to the read style. I can only think the idea was to keep what was already there? But if a read style is picked, then to my mind that should be used.

I'll do the read styles in another PR. With that, it may make sense to add another tab (or section) for the read and write styles in the GUI options.