### PR TITLE
Autotag source

### DIFF
--- a/comictaggerlib/autotagprogresswindow.py
+++ b/comictaggerlib/autotagprogresswindow.py
@@ -35,6 +35,8 @@ class AutoTagProgressWindow(QtWidgets.QDialog):
         with (ui_path / "autotagprogresswindow.ui").open(encoding="utf-8") as uifile:
             uic.loadUi(uifile, self)
 
+        self.lblSourceName.setText(talker.attribution)
+
         self.archiveCoverWidget = CoverImageWidget(
             self.archiveCoverContainer, CoverImageWidget.DataMode, None, None, False
         )

--- a/comictaggerlib/ui/autotagprogresswindow.ui
+++ b/comictaggerlib/ui/autotagprogresswindow.ui
@@ -65,8 +65,8 @@
     </widget>
    </item>
    <item row="1" column="2">
-    <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0" columnstretch="1,0">
-     <item row="4" column="1">
+    <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0" columnstretch="1,0">
+     <item row="5" column="1">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -79,7 +79,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="lblSourceName">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -92,7 +92,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="2">
+     <item row="4" column="0" colspan="2">
       <widget class="QTextEdit" name="textEdit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -126,7 +126,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="2">
+     <item row="3" column="0" colspan="2">
       <widget class="QLabel" name="label">
        <property name="text">
         <string/>

--- a/comictaggerlib/ui/autotagprogresswindow.ui
+++ b/comictaggerlib/ui/autotagprogresswindow.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>900</width>
-    <height>413</height>
+    <height>456</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="maximumSize">
    <size>
@@ -20,7 +26,23 @@
    <string>Issue Identification Progress</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
+   <item row="1" column="4">
+    <widget class="QWidget" name="testCoverContainer" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>110</width>
+       <height>165</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>110</width>
+       <height>165</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
     <widget class="QWidget" name="archiveCoverContainer" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
@@ -42,43 +64,42 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="4">
-    <widget class="QWidget" name="testCoverContainer" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>110</width>
-       <height>165</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>110</width>
-       <height>165</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QProgressBar" name="progressBar">
-       <property name="value">
-        <number>0</number>
+   <item row="1" column="2">
+    <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0" columnstretch="1,0">
+     <item row="4" column="1">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-       <property name="invertedAppearance">
-        <bool>false</bool>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel</set>
+       </property>
+       <property name="centerButtons">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QLabel" name="label">
+     <item row="4" column="0">
+      <widget class="QLabel" name="lblSourceName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string/>
+        <string>Metadata source</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="3" column="0" colspan="2">
       <widget class="QTextEdit" name="textEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="font">
         <font>
          <family>Courier</family>
@@ -89,16 +110,26 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+     <item row="2" column="0" colspan="2">
+      <widget class="QProgressBar" name="progressBar">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel</set>
+       <property name="value">
+        <number>0</number>
        </property>
-       <property name="centerButtons">
-        <bool>true</bool>
+       <property name="invertedAppearance">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Missed this one when adding source attribution. Adds the talker `attribution` on the same row as the cancel button.
![image](https://github.com/comictagger/comictagger/assets/1141189/3b12b491-1128-4cef-be42-2b188e9e2489)
