### PR TITLE
Use custom delegate to unify combobox item style

### DIFF
--- a/comictaggerlib/ui/customwidgets.py
+++ b/comictaggerlib/ui/customwidgets.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from enum import auto
 from sys import platform
-import platform
 from typing import Any
 
 from PyQt5 import QtGui, QtWidgets


### PR DESCRIPTION
On Linux (tested) changes:
![image](https://github.com/comictagger/comictagger/assets/1141189/13d09196-c4a4-470b-823f-119a2ae17b99)
Which are oversized checkboxes to:
![image](https://github.com/comictagger/comictagger/assets/1141189/486aba56-d332-4dff-8bdb-5c3bd1e4de92)
