### PR TITLE
Preserve hidden metadata values when reading from GUI form

### DIFF
--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -940,6 +940,16 @@ class TaggerWindow(QtWidgets.QMainWindow):
             md.add_credit(name, role, bool(primary_flag))
 
         md.pages = self.page_list_editor.get_page_list()
+
+        # Preserve hidden md values
+        md.data_origin = self.metadata.data_origin
+        md.issue_id = self.metadata.issue_id
+        md.series_id = self.metadata.series_id
+
+        md.price = self.metadata.price
+        md.identifier = self.metadata.identifier
+        md.rights = self.metadata.rights
+
         self.metadata = md
 
     def use_filename(self) -> None:


### PR DESCRIPTION
Currently when `write_tags` is used, `form_to_metadata` is called within it which means any "hidden" values such as `data-origin`, `identifier`, `price`, `rights`, `issue_id`, `series_id`, `is_version_of` and `last_mark` are erased.

Some of these values are/may be of use to a tag plugin. (Saving the `issue_is` and `series_id` in ACBF for example.)

I'm not sure if doing it in the `form_to_metadata` will cause problems anywhere else? The other option I considered was to pull the values out in the `write_tags` method and then place them back after `form_to_metadata`.