### PR TITLE
Add winget submission GitHub action

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,0 +1,27 @@
+name: Submit ComicTagger.ComicTagger package to Windows Package Manager Community Repository
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          PACKAGE_ID: "ComicTagger.ComicTagger"
+        run: |
+          # Fetching latest release from GitHub
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/comictagger/comictagger/releases"
+          $targetRelease = $github | Select-Object -First 1
+
+          $installerUrl = $targetRelease | Select-Object -ExpandProperty assets -First 1 | Where-Object -Property name -match 'ComicTagger-.*.zip' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = $targetRelease.tag_name
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $env:PACKAGE_ID --version $packageVersion --urls "$installerUrl" --submit --token $env:GH_TOKEN

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/comictagger)](https://pypi.org/project/comictagger/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/comictagger)](https://pypistats.org/packages/comictagger)
 [![Chocolatey package](https://img.shields.io/chocolatey/dt/comictagger?color=blue&label=chocolatey)](https://community.chocolatey.org/packages/comictagger)
+[![WinGet](https://img.shields.io/winget/v/ComicTagger.ComicTagger)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/ComicTagger/ComicTagger)
 [![PyPI - License](https://img.shields.io/pypi/l/comictagger)](https://opensource.org/licenses/Apache-2.0)
 
 [![GitHub Discussions](https://img.shields.io/github/discussions/comictagger/comictagger)](https://github.com/comictagger/comictagger/discussions)


### PR DESCRIPTION
This PR adds a GitHub action that automatically creates new package PRs in the winget-pkgs repository everytime a new release is published.

Additional to this PR it needs a GitHub secret named WINGET_TOKEN. The token should contain a Personal Access Token (See the following link).

https://github.com/microsoft/winget-create/blob/main/README.md#github-personal-access-token-classic-permissions

#589 