### PR TITLE
Only display metadata source info if results were found

### DIFF
--- a/comictaggerlib/cli.py
+++ b/comictaggerlib/cli.py
@@ -121,7 +121,7 @@ class CLI:
 
         self.post_process_matches(match_results)
 
-        if self.config.Auto_Tag__online and results[-1].online_results != []:
+        if self.config.Auto_Tag__online and results and results[-1].online_results != []:
             self.output(
                 f"\nFiles tagged with metadata provided by {self.current_talker().name} {self.current_talker().website}",
             )

--- a/comictaggerlib/cli.py
+++ b/comictaggerlib/cli.py
@@ -121,7 +121,7 @@ class CLI:
 
         self.post_process_matches(match_results)
 
-        if self.config.Auto_Tag__online:
+        if self.config.Auto_Tag__online and results[-1].online_results != []:
             self.output(
                 f"\nFiles tagged with metadata provided by {self.current_talker().name} {self.current_talker().website}",
             )


### PR DESCRIPTION
The CLI systematically displays a line like
```
2025-01-27T17:40:54 | comictaggerlib.cli | INFO | Files tagged with metadata provided by Comic Vine https://comicvine.gamespot.com
```
when `-o` is used, even if not matches were found and no tags were written, Which may be quite confusing.

This PR proposes to only display the line if results were actually found online.