### PR TITLE
Add source info to auto-tag summary window

### DIFF
--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1974,7 +1974,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
             self.load_archive(new_ca)
         self.atprogdialog = None
 
-        summary = ""
+        summary = f"<p>{self.current_talker().attribution}</p>"
         summary += f"Successfully added {tag_names} tags to {len(match_results.good_matches)} archive(s)\n"
 
         if len(match_results.multiple_matches) > 0:


### PR DESCRIPTION
Uses the `attribution` string of the talker.

![image](https://github.com/user-attachments/assets/9ae059d0-acaf-40dc-8d0f-e62b9f18b1c4)
