### PR TITLE
Add URL to ImageHash and use in issue window

### DIFF
--- a/comicapi/genericmetadata.py
+++ b/comicapi/genericmetadata.py
@@ -139,9 +139,10 @@ class MetadataOrigin(NamedTuple):
 class ImageHash(NamedTuple):
     Hash: int
     Kind: str  # ahash, phash
+    URL: str | None = None
 
     def __str__(self) -> str:
-        return str(self.Hash) + ": " + self.Kind
+        return self.URL or ""
 
 
 @dataclasses.dataclass

--- a/comicapi/genericmetadata.py
+++ b/comicapi/genericmetadata.py
@@ -137,12 +137,16 @@ class MetadataOrigin(NamedTuple):
 
 
 class ImageHash(NamedTuple):
-    Hash: int
-    Kind: str  # ahash, phash
-    URL: str | None = None
+    """
+    A valid ImageHash requires at a minimum a Hash and Kind or a URL
+    If only a URL is given, it will be used for cover matching otherwise Hash is used
+    The URL is also required for the GUI to display covers
+    Available Kind's are "ahash" and "phash"
+    """
 
-    def __str__(self) -> str:
-        return self.URL or ""
+    Hash: int
+    Kind: str
+    URL: str
 
 
 @dataclasses.dataclass
@@ -211,8 +215,8 @@ class GenericMetadata:
     last_mark: str | None = None
 
     # urls to cover image, not generally part of the metadata
-    _cover_image: str | ImageHash | None = None
-    _alternate_images: list[str | ImageHash] = dataclasses.field(default_factory=list)
+    _cover_image: ImageHash | None = None
+    _alternate_images: list[ImageHash] = dataclasses.field(default_factory=list)
 
     def __post_init__(self) -> None:
         for key, value in self.__dict__.items():

--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -314,40 +314,34 @@ class IssueIdentifier:
         # local_hashes is a list of pre-calculated hashes.
         # use_alt_urls - indicates to use alternate covers
 
-        # If there is no ImageHash or no URL and Hash, return 100 for a bad match
-        if primary_img_url is None or (primary_img_url.Hash == 0 and not primary_img_url.URL and not use_alt_urls):
+        # If there is no ImageHash or no URL and Kind, return 100 for a bad match
+        if primary_img_url is None or (not primary_img_url.Kind and not primary_img_url.URL and not use_alt_urls):
             return Score(score=100, url="", remote_hash=0, local_hash=0, local_hash_name="0")
 
         self._user_canceled()
 
         remote_hashes = []
 
-        try:
-            if primary_img_url.Hash != 0 and primary_img_url.Kind:
-                remote_hashes.append((primary_img_url.URL or "", primary_img_url.Hash))
-                self.log_msg(
-                    f"Using source talker hash for cover matching. Hash: {primary_img_url.Hash}, Kind: {primary_img_url.Kind}"
-                )
-            elif primary_img_url.URL:
-                remote_hashes = self._get_remote_hashes([primary_img_url.URL])
-                self.log_msg("Using URL download image for cover matching.")
-        except Exception as e:
-            logger.warning("Failed to process primary ImageHash: %s", e)
+        if primary_img_url.Kind:
+            remote_hashes.append((primary_img_url.URL, primary_img_url.Hash))
+            self.log_msg(
+                f"Using provided hash for cover matching. Hash: {primary_img_url.Hash}, Kind: {primary_img_url.Kind}"
+            )
+        elif primary_img_url.URL:
+            remote_hashes = self._get_remote_hashes([primary_img_url.URL])
+            self.log_msg(f"Downloading image for cover matching: {primary_img_url.URL}")
 
         if use_alt_urls and alt_urls:
-            try:
-                only_urls = []
-                for alt_url in alt_urls:
-                    if alt_url.Hash != 0 and alt_url.Kind:
-                        remote_hashes.append((alt_url.URL or "", alt_url.Hash))
-                    elif alt_url.URL:
-                        only_urls.append(alt_url.URL)
-                if only_urls:
-                    remote_hashes.extend(self._get_remote_hashes(only_urls))
+            only_urls = []
+            for alt_url in alt_urls:
+                if alt_url.Kind:
+                    remote_hashes.append((alt_url.URL, alt_url.Hash))
+                elif alt_url.URL:
+                    only_urls.append(alt_url.URL)
+            if only_urls:
+                remote_hashes.extend(self._get_remote_hashes(only_urls))
 
-                self.log_msg(f"[{len(remote_hashes) - 1} alt. covers]")
-            except Exception as e:
-                logger.warning("Failed to process alternative ImageHash(s): %s", e)
+            self.log_msg(f"[{len(remote_hashes) - 1} alt. covers]")
 
         score_list = []
         done = False
@@ -540,7 +534,7 @@ class IssueIdentifier:
             try:
                 # We only include urls in the IssueResult so we don't have to deal with it down the line
                 # TODO: display the hash to the user so they know a direct hash was used instead of downloading an image
-                alt_urls: list[str] = [img.URL or "" for img in issue._alternate_images]
+                alt_urls: list[str] = [img.URL for img in issue._alternate_images]
 
                 score_item = self._get_issue_cover_match_score(
                     issue._cover_image, issue._alternate_images, hashes, use_alt_urls=use_alternates

--- a/comictaggerlib/issueidentifier.py
+++ b/comictaggerlib/issueidentifier.py
@@ -306,35 +306,48 @@ class IssueIdentifier:
 
     def _get_issue_cover_match_score(
         self,
-        primary_img_url: str | ImageHash,
-        alt_urls: list[str | ImageHash],
+        primary_img_url: ImageHash | None,
+        alt_urls: list[ImageHash],
         local_hashes: list[tuple[str, int]],
         use_alt_urls: bool = False,
     ) -> Score:
         # local_hashes is a list of pre-calculated hashes.
-        # use_alt_urls - indicates to use alternate covers from CV
+        # use_alt_urls - indicates to use alternate covers
 
-        # If there is no URL return 100
-        if not primary_img_url:
+        # If there is no ImageHash or no URL and Hash, return 100 for a bad match
+        if primary_img_url is None or (primary_img_url.Hash == 0 and not primary_img_url.URL and not use_alt_urls):
             return Score(score=100, url="", remote_hash=0, local_hash=0, local_hash_name="0")
 
         self._user_canceled()
 
         remote_hashes = []
-        # If the cover is ImageHash and the alternate covers are URLs, the alts will not be hashed/checked currently
-        if isinstance(primary_img_url, ImageHash):
-            # ImageHash doesn't have a url so we just give it an empty string
-            remote_hashes.append(("", primary_img_url.Hash))
-            if use_alt_urls and alt_urls:
-                remote_hashes.extend(("", alt_hash.Hash) for alt_hash in alt_urls if isinstance(alt_hash, ImageHash))
-        else:
-            urls = [primary_img_url]
-            if use_alt_urls:
-                only_urls = [url for url in alt_urls if isinstance(url, str)]
-                urls.extend(only_urls)
-                self.log_msg(f"[{len(only_urls)} alt. covers]")
 
-            remote_hashes = self._get_remote_hashes(urls)
+        try:
+            if primary_img_url.Hash != 0 and primary_img_url.Kind:
+                remote_hashes.append((primary_img_url.URL or "", primary_img_url.Hash))
+                self.log_msg(
+                    f"Using source talker hash for cover matching. Hash: {primary_img_url.Hash}, Kind: {primary_img_url.Kind}"
+                )
+            elif primary_img_url.URL:
+                remote_hashes = self._get_remote_hashes([primary_img_url.URL])
+                self.log_msg("Using URL download image for cover matching.")
+        except Exception as e:
+            logger.warning("Failed to process primary ImageHash: %s", e)
+
+        if use_alt_urls and alt_urls:
+            try:
+                only_urls = []
+                for alt_url in alt_urls:
+                    if alt_url.Hash != 0 and alt_url.Kind:
+                        remote_hashes.append((alt_url.URL or "", alt_url.Hash))
+                    elif alt_url.URL:
+                        only_urls.append(alt_url.URL)
+                if only_urls:
+                    remote_hashes.extend(self._get_remote_hashes(only_urls))
+
+                self.log_msg(f"[{len(remote_hashes) - 1} alt. covers]")
+            except Exception as e:
+                logger.warning("Failed to process alternative ImageHash(s): %s", e)
 
         score_list = []
         done = False
@@ -525,13 +538,12 @@ class IssueIdentifier:
             )
 
             try:
-                image_url = issue._cover_image if isinstance(issue._cover_image, str) else ""
                 # We only include urls in the IssueResult so we don't have to deal with it down the line
                 # TODO: display the hash to the user so they know a direct hash was used instead of downloading an image
-                alt_urls: list[str] = [url for url in issue._alternate_images if isinstance(url, str)]
+                alt_urls: list[str] = [img.URL or "" for img in issue._alternate_images]
 
                 score_item = self._get_issue_cover_match_score(
-                    image_url, issue._alternate_images, hashes, use_alt_urls=use_alternates
+                    issue._cover_image, issue._alternate_images, hashes, use_alt_urls=use_alternates
                 )
             except Exception:
                 logger.exception(f"Scoring series{alternate} covers failed")
@@ -549,7 +561,7 @@ class IssueIdentifier:
                 month=issue.month,
                 year=issue.year,
                 publisher=None,
-                image_url=image_url,
+                image_url=issue._cover_image.URL if issue._cover_image else "",
                 alt_image_urls=alt_urls,
                 description=issue.description or "",
             )

--- a/comictaggerlib/issueselectionwindow.py
+++ b/comictaggerlib/issueselectionwindow.py
@@ -223,8 +223,9 @@ class IssueSelectionWindow(QtWidgets.QDialog):
         self.issue_number = issue.issue or ""
         # We don't currently have a way to display hashes to the user
         # TODO: display the hash to the user so they know it will be used for cover matching
-        alt_images = [str(url) for url in issue._alternate_images]
-        self.coverWidget.set_issue_details(self.issue_id, [str(issue._cover_image) or "", *alt_images])
+        alt_images = [url.URL for url in issue._alternate_images]
+        cover = issue._cover_image.URL if issue._cover_image else ""
+        self.coverWidget.set_issue_details(self.issue_id, [cover, *alt_images])
         if issue.description is None:
             self.set_description(self.teDescription, "")
         else:

--- a/comictaggerlib/issueselectionwindow.py
+++ b/comictaggerlib/issueselectionwindow.py
@@ -223,7 +223,7 @@ class IssueSelectionWindow(QtWidgets.QDialog):
         self.issue_number = issue.issue or ""
         # We don't currently have a way to display hashes to the user
         # TODO: display the hash to the user so they know it will be used for cover matching
-        alt_images = [url for url in issue._alternate_images if isinstance(url, str)]
+        alt_images = [str(url) for url in issue._alternate_images]
         self.coverWidget.set_issue_details(self.issue_id, [str(issue._cover_image) or "", *alt_images])
         if issue.description is None:
             self.set_description(self.teDescription, "")

--- a/comictalker/talkers/comicvine.py
+++ b/comictalker/talkers/comicvine.py
@@ -30,7 +30,7 @@ from pyrate_limiter import Limiter, RequestRate
 from typing_extensions import Required, TypedDict
 
 from comicapi import utils
-from comicapi.genericmetadata import ComicSeries, GenericMetadata, MetadataOrigin
+from comicapi.genericmetadata import ComicSeries, GenericMetadata, ImageHash, MetadataOrigin
 from comicapi.issuestring import IssueString
 from comicapi.utils import LocationParseError, parse_url
 from comictalker import talker_utils
@@ -875,13 +875,11 @@ class ComicVineTalker(ComicTalker):
                 md.web_links = [parse_url(url)]
             except LocationParseError:
                 ...
-        if issue.get("image") is None:
-            md._cover_image = ""
-        else:
-            md._cover_image = issue.get("image", {}).get("super_url", "")
+        if issue.get("image") is not None:
+            md._cover_image = ImageHash(URL=issue.get("image", {}).get("super_url", ""), Hash=0, Kind="")
 
         for alt in issue.get("associated_images", []):
-            md._alternate_images.append(alt["original_url"])
+            md._alternate_images.append(ImageHash(URL=alt["original_url"], Hash=0, Kind=""))
 
         for character in issue.get("character_credits", set()):
             md.characters.add(character["name"])

--- a/testing/comicdata.py
+++ b/testing/comicdata.py
@@ -306,10 +306,10 @@ issueidentifier_score = (  # type: ignore[var-annotated]
     ),
     (
         (
-            # Test invalid ImageHash values
+            # Test invalid ImageHash Kind value
             comicapi.genericmetadata.ImageHash(
                 Hash=0,
-                Kind="ahash",
+                Kind="",
                 URL="",
             ),
             [],

--- a/testing/comicdata.py
+++ b/testing/comicdata.py
@@ -289,27 +289,68 @@ metadata_prepared = (
     ),
 )
 
-issueidentifier_score = (
+issueidentifier_score = (  # type: ignore[var-annotated]
     (
         (
-            comicapi.genericmetadata.ImageHash(
-                Hash=0,  # Force using the alternate, since the alternate is a url it will be ignored
-                Kind="ahash",
-                URL="",
-            ),
-            ["https://comicvine.gamespot.com/cory-doctorows-futuristic-tales-of-the-here-and-no/4000-140529/"],
-            True,
+            None,
+            [],
+            False,
         ),
         {
             "remote_hash": 0,
-            "score": 31,
+            "score": 100,
             "url": "",
+            "local_hash": 0,
+            "local_hash_name": "0",
+        },
+    ),
+    (
+        (
+            # Test invalid ImageHash values
+            comicapi.genericmetadata.ImageHash(
+                Hash=0,
+                Kind="ahash",
+                URL="",
+            ),
+            [],
+            False,
+        ),
+        {
+            "remote_hash": 0,
+            "score": 100,
+            "url": "",
+            "local_hash": 0,
+            "local_hash_name": "0",
+        },
+    ),
+    (
+        (
+            # Test URL alternative
+            comicapi.genericmetadata.ImageHash(
+                Hash=0,
+                Kind="ahash",
+                URL="",
+            ),
+            [
+                comicapi.genericmetadata.ImageHash(
+                    URL="https://comicvine.gamespot.com/a/uploads/scale_large/0/574/585444-109004_20080707014047_large.jpg",
+                    Hash=0,
+                    Kind="",
+                )
+            ],
+            True,
+        ),
+        {
+            "remote_hash": 212201432349720,
+            "score": 0,
+            "url": "https://comicvine.gamespot.com/a/uploads/scale_large/0/574/585444-109004_20080707014047_large.jpg",
             "local_hash": 212201432349720,
             "local_hash_name": "Cover 1",
         },
     ),
     (
         (
+            # Test hash alternative
             comicapi.genericmetadata.ImageHash(
                 Hash=0,
                 Kind="ahash",
@@ -339,7 +380,7 @@ issueidentifier_score = (
                 Kind="ahash",
                 URL="",
             ),
-            ["https://comicvine.gamespot.com/cory-doctorows-futuristic-tales-of-the-here-and-no/4000-140529/"],
+            [],
             False,
         ),
         {
@@ -352,8 +393,12 @@ issueidentifier_score = (
     ),
     (
         (
-            "https://comicvine.gamespot.com/a/uploads/scale_large/0/574/585444-109004_20080707014047_large.jpg",
-            ["https://comicvine.gamespot.com/cory-doctorows-futuristic-tales-of-the-here-and-no/4000-140529/"],
+            comicapi.genericmetadata.ImageHash(
+                Hash=0,
+                Kind="",
+                URL="https://comicvine.gamespot.com/a/uploads/scale_large/0/574/585444-109004_20080707014047_large.jpg",
+            ),
+            [],
             False,
         ),
         {

--- a/testing/comicdata.py
+++ b/testing/comicdata.py
@@ -295,6 +295,7 @@ issueidentifier_score = (
             comicapi.genericmetadata.ImageHash(
                 Hash=0,  # Force using the alternate, since the alternate is a url it will be ignored
                 Kind="ahash",
+                URL="",
             ),
             ["https://comicvine.gamespot.com/cory-doctorows-futuristic-tales-of-the-here-and-no/4000-140529/"],
             True,
@@ -312,11 +313,13 @@ issueidentifier_score = (
             comicapi.genericmetadata.ImageHash(
                 Hash=0,
                 Kind="ahash",
+                URL="",
             ),
             [
                 comicapi.genericmetadata.ImageHash(
                     Hash=212201432349720,
                     Kind="ahash",
+                    URL="",
                 ),
             ],
             True,
@@ -334,6 +337,7 @@ issueidentifier_score = (
             comicapi.genericmetadata.ImageHash(
                 Hash=212201432349720,
                 Kind="ahash",
+                URL="",
             ),
             ["https://comicvine.gamespot.com/cory-doctorows-futuristic-tales-of-the-here-and-no/4000-140529/"],
             False,

--- a/testing/comicvine.py
+++ b/testing/comicvine.py
@@ -181,7 +181,9 @@ comic_issue_result = comicapi.genericmetadata.GenericMetadata(
     issue_id=str(cv_issue_result["results"]["id"]),
     series=cv_issue_result["results"]["volume"]["name"],
     series_id=str(cv_issue_result["results"]["volume"]["id"]),
-    _cover_image=cv_issue_result["results"]["image"]["super_url"],
+    _cover_image=comicapi.genericmetadata.ImageHash(
+        URL=cv_issue_result["results"]["image"]["super_url"], Hash=0, Kind=""
+    ),
     issue=cv_issue_result["results"]["issue_number"],
     volume=None,
     title=cv_issue_result["results"]["name"],
@@ -240,7 +242,9 @@ cv_md = comicapi.genericmetadata.GenericMetadata(
     rights=None,
     identifier=None,
     last_mark=None,
-    _cover_image=cv_issue_result["results"]["image"]["super_url"],
+    _cover_image=comicapi.genericmetadata.ImageHash(
+        URL=cv_issue_result["results"]["image"]["super_url"], Hash=0, Kind=""
+    ),
 )
 
 

--- a/tests/issueidentifier_test.py
+++ b/tests/issueidentifier_test.py
@@ -42,7 +42,7 @@ def test_get_issue_cover_match_score(
     cbz,
     config,
     comicvine_api,
-    data: tuple[str | ImageHash, list[str | ImageHash], bool],
+    data: tuple[ImageHash, list[ImageHash], bool],
     expected: comictaggerlib.issueidentifier.Score,
 ):
     config, definitions = config


### PR DESCRIPTION
This allows to use of `ImageHash` and for the issue window to display covers.

`alt_images = [str(url) for url in issue._alternate_images]` I didn't roll into `[str(issue._cover_image) or "", *alt_images]` for ease of reading.