### PR TITLE
Add error catching to locale.getlocale()

### DIFF
--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -87,7 +87,7 @@ def configure_locale() -> None:
         code = _lang_code_mac()
         if code != "":
             os.environ["LANG"] = f"{code}.utf-8"
-            
+
     #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
     try:
         locale.setlocale(locale.LC_ALL, '')

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -87,8 +87,15 @@ def configure_locale() -> None:
         code = _lang_code_mac()
         if code != "":
             os.environ["LANG"] = f"{code}.utf-8"
-
-    locale.setlocale(locale.LC_ALL, "")
+            
+    #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        try:
+            locale.setlocale(locale.LC_ALL, ‘en_US.UTF-8’)
+        except locale.Error:
+            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
     sys.stdout.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stderr.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stdin.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]


### PR DESCRIPTION
Add error handling and fallbacks to en_US or C as language locale in case of misconfigured or minimal system.
This fixes issue #740