### PR TITLE
Add error catching to locale.getlocale(locale.LC_ALL, "")

### DIFF
--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -88,7 +88,7 @@ def configure_locale() -> None:
         if code != "":
             os.environ["LANG"] = f"{code}.utf-8"
 
-    #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
+    # Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
     try:
         locale.setlocale(locale.LC_ALL, "")
     except locale.Error:

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -90,12 +90,12 @@ def configure_locale() -> None:
 
     #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
     try:
-        locale.setlocale(locale.LC_ALL, '')
+        locale.setlocale(locale.LC_ALL, "")
     except locale.Error:
         try:
-            locale.setlocale(locale.LC_ALL, ‘en_US.UTF-8’)
+            locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
         except locale.Error:
-            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+            locale.setlocale(locale.LC_ALL, "C.UTF-8")
     sys.stdout.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stderr.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stdin.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -87,7 +87,7 @@ def configure_locale() -> None:
         code = _lang_code_mac()
         if code != "":
             os.environ["LANG"] = f"{code}.utf-8"
-            
+
     #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
     try:
         locale.setlocale(locale.LC_ALL, '')

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -87,8 +87,15 @@ def configure_locale() -> None:
         code = _lang_code_mac()
         if code != "":
             os.environ["LANG"] = f"{code}.utf-8"
-
-    locale.setlocale(locale.LC_ALL, "")
+            
+    #Get locale settings from OS, fall back to en_US or C in case of error for minimalist or misconfigured systems
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        try:
+            locale.setlocale(locale.LC_ALL, ‘en_US.UTF-8’)
+        except locale.Error:
+            locale.setlocale(locale.LC_ALL, 'C.UTF-8')
     sys.stdout.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stderr.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stdin.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -92,10 +92,8 @@ def configure_locale() -> None:
     try:
         locale.setlocale(locale.LC_ALL, "")
     except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, "en_US")
-        except locale.Error:
-            locale.setlocale(locale.LC_ALL, "C")
+        locale.setlocale(locale.LC_ALL, "C")
+        logger.error("Couldn't set the locale: unsupported locale setting; falling back to 'C' locale")
     sys.stdout.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stderr.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stdin.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]

--- a/comictaggerlib/main.py
+++ b/comictaggerlib/main.py
@@ -93,9 +93,9 @@ def configure_locale() -> None:
         locale.setlocale(locale.LC_ALL, "")
     except locale.Error:
         try:
-            locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+            locale.setlocale(locale.LC_ALL, "en_US")
         except locale.Error:
-            locale.setlocale(locale.LC_ALL, "C.UTF-8")
+            locale.setlocale(locale.LC_ALL, "C")
     sys.stdout.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stderr.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]
     sys.stdin.reconfigure(encoding=sys.getdefaultencoding())  # type: ignore[union-attr]


### PR DESCRIPTION
Add error handling and fallbacks to en_US or C as language locale in case of misconfigured or minimal system.
Fixes issue #740