### PR TITLE
Sort plugins by version number

### DIFF
--- a/comictaggerlib/ctsettings/plugin_finder.py
+++ b/comictaggerlib/ctsettings/plugin_finder.py
@@ -179,6 +179,10 @@ def _classify_plugins(plugins: list[LoadedPlugin]) -> Plugins:
         else:
             logger.warning(NotImplementedError(f"what plugin type? {p}"))
 
+    talkers.sort(key=lambda x: x.plugin.version)
+    tags.sort(key=lambda x: x.plugin.version)
+    archivers.sort(key=lambda x: x.plugin.version)
+
     return Plugins(
         tags=tags,
         archivers=archivers,


### PR DESCRIPTION
so the last plugin that will be loaded will be the latest version.

This seems to work with simple numbering but it may be save to parse to Version for the comparison.