### PR TITLE
Resolve bs4 deprecation warnings

### DIFF
--- a/comictalker/talker_utils.py
+++ b/comictalker/talker_utils.py
@@ -78,15 +78,15 @@ def cleanup_html(string: str | None, remove_html_tables: bool = False) -> str:
                 rows = []
                 hdrs = []
                 col_widths = []
-                for hdr in table.findAll("th"):
+                for hdr in table.find_all("th"):
                     item = hdr.string.strip()
                     hdrs.append(item)
                     col_widths.append(len(item))
                 rows.append(hdrs)
 
-                for row in table.findAll("tr"):
+                for row in table.find_all("tr"):
                     cols = []
-                    col = row.findAll("td")
+                    col = row.find_all("td")
 
                     for i, c in enumerate(col):
                         item = c.string.strip()


### PR DESCRIPTION
# PR Summary
This small PR fixes the bs4 deprecation warnings by replacing `findAll()` with `find_all()`:
```python
/Users/runner/work/comictagger/comictagger/comictalker/talker_utils.py:46: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
```
This is continuation of commit ad26ee7818ee13cef1fb1e3c77f60ebd22e3cf4c. 