### PR TITLE
Add support for GTIN identifier

### DIFF
--- a/comicapi/genericmetadata.py
+++ b/comicapi/genericmetadata.py
@@ -203,6 +203,8 @@ class GenericMetadata:
     story_arcs: list[str] = dataclasses.field(default_factory=list)
     series_groups: list[str] = dataclasses.field(default_factory=list)
 
+    gtin: str | None = None  # ISBN/EAN identifier
+
     publisher: str | None = None
     imprint: str | None = None
     day: int | None = None
@@ -339,6 +341,8 @@ class GenericMetadata:
         self.alternate_count = assign(self.alternate_count, new_md.alternate_count)
         self.story_arcs = assign_list(self.story_arcs, new_md.story_arcs)
         self.series_groups = assign_list(self.series_groups, new_md.series_groups)
+
+        self.gtin = assign(self.gtin, new_md.gtin)
 
         self.publisher = assign(self.publisher, new_md.publisher)
         self.imprint = assign(self.imprint, new_md.imprint)
@@ -509,6 +513,7 @@ class GenericMetadata:
         add_string("web_links", [str(x) for x in self.web_links])
         add_string("format", self.format)
         add_string("manga", self.manga)
+        add_string("gtin", self.gtin)
 
         add_string("price", self.price)
         add_string("is_version_of", self.is_version_of)
@@ -596,6 +601,7 @@ md_test: GenericMetadata = GenericMetadata(
     alternate_series="Tales",
     alternate_number="2",
     alternate_count=7,
+    gtin=None,
     imprint="craphound.com",
     notes="Tagged with ComicTagger 1.3.2a5 using info from Comic Vine on 2022-04-16 15:52:26. [Issue ID 140529]",
     web_links=[

--- a/comicapi/tags/comicrack.py
+++ b/comicapi/tags/comicrack.py
@@ -49,7 +49,6 @@ class ComicRack(Tag):
             "alternate_series",
             "alternate_number",
             "alternate_count",
-            "gtin",
             "story_arcs",
             "series_groups",
             "publisher",
@@ -233,7 +232,6 @@ class ComicRack(Tag):
         assign("AlternateCount", md.alternate_count)
         assign("StoryArc", md.story_arcs)
         assign("SeriesGroup", md.series_groups)
-        assign("GTIN", md.gtin)
 
         assign("Publisher", md.publisher)
         assign("Imprint", md.imprint)
@@ -321,7 +319,6 @@ class ComicRack(Tag):
         md.alternate_count = utils.xlate_int(get("AlternateCount"))
         md.story_arcs = utils.split(get("StoryArc"), ",")
         md.series_groups = utils.split(get("SeriesGroup"), ",")
-        md.gtin = utils.xlate(get("GTIN"))
 
         md.publisher = utils.xlate(get("Publisher"))
         md.imprint = utils.xlate(get("Imprint"))

--- a/comicapi/tags/comicrack.py
+++ b/comicapi/tags/comicrack.py
@@ -49,6 +49,7 @@ class ComicRack(Tag):
             "alternate_series",
             "alternate_number",
             "alternate_count",
+            "gtin",
             "story_arcs",
             "series_groups",
             "publisher",
@@ -232,6 +233,7 @@ class ComicRack(Tag):
         assign("AlternateCount", md.alternate_count)
         assign("StoryArc", md.story_arcs)
         assign("SeriesGroup", md.series_groups)
+        assign("GTIN", md.gtin)
 
         assign("Publisher", md.publisher)
         assign("Imprint", md.imprint)
@@ -319,6 +321,7 @@ class ComicRack(Tag):
         md.alternate_count = utils.xlate_int(get("AlternateCount"))
         md.story_arcs = utils.split(get("StoryArc"), ",")
         md.series_groups = utils.split(get("SeriesGroup"), ",")
+        md.gtin = utils.xlate(get("GTIN"))
 
         md.publisher = utils.xlate(get("Publisher"))
         md.imprint = utils.xlate(get("Imprint"))

--- a/comicapi/tags/tag.py
+++ b/comicapi/tags/tag.py
@@ -29,6 +29,7 @@ class Tag:
             "alternate_series",
             "alternate_number",
             "alternate_count",
+            "gtin",
             "story_arcs",
             "series_groups",
             "publisher",

--- a/comictaggerlib/gtinvalidator.py
+++ b/comictaggerlib/gtinvalidator.py
@@ -1,4 +1,4 @@
-"""Functions for validation the GTIN field"""
+"""Functions for validating the GTIN field"""
 
 #
 # Copyright 2012-2014 ComicTagger Authors

--- a/comictaggerlib/gtinvalidator.py
+++ b/comictaggerlib/gtinvalidator.py
@@ -1,0 +1,51 @@
+"""Functions for validation the GTIN field"""
+
+#
+# Copyright 2012-2014 ComicTagger Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+
+def is_valid_gtin(gtin: str) -> bool:
+    """Check if the GTIN is valid.
+
+    Args:
+        gtin (str): The GTIN to validate.
+
+    Returns:
+        bool: True if the GTIN is valid, False otherwise.
+    """
+    gtin = gtin.strip().replace("-", "").replace(" ", "")
+
+    if not gtin or len(gtin) not in (8, 12, 13, 14):
+        return False
+
+    try:
+        digits = [int(d) for d in gtin]
+    except ValueError:
+        return False
+
+    # Using the same algorithm since all GTIN
+    # codes are validated the same way.
+    # Also just checking mathematically and not against a GTIN database
+    control_number = 0
+    for i, digit in enumerate(digits[:-1]):
+        if i % 2 == 0:
+            control_number += digit * 1
+        else:
+            control_number += digit * 3
+    control_number = (10 - (control_number % 10)) % 10
+
+    return control_number == digits[-1]

--- a/comictaggerlib/settingswindow.py
+++ b/comictaggerlib/settingswindow.py
@@ -91,6 +91,7 @@ Accepts the following variables:
 {alternate_series} (string)
 {alternate_number} (string)
 {alternate_count}  (integer)
+{gtin}             (string)
 {imprint}          (string)
 {notes}            (string)
 {web_link}         (string)

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -113,6 +113,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
             "alternate_series": self.leAltSeries,
             "alternate_number": self.leAltIssueNum,
             "alternate_count": self.leAltIssueCount,
+            "gtin": self.leGtin,
             "imprint": self.leImprint,
             "notes": self.teNotes,
             "web_links": (self.leWebLink, self.btnOpenWebLink, self.btnAddWebLink, self.btnRemoveWebLink),
@@ -843,6 +844,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
         assign_text(self.leAltSeries, md.alternate_series)
         assign_text(self.leAltIssueNum, md.alternate_number)
         assign_text(self.leAltIssueCount, md.alternate_count)
+        assign_text(self.leGtin, md.gtin)
         self.leWebLink.clear()
         for u in md.web_links:
             self.add_weblink_item(u.url)
@@ -985,6 +987,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
         md.scan_info = utils.xlate(self.leScanInfo.text())
         md.series_groups = utils.split(self.leSeriesGroup.text(), ",")
         md.alternate_series = self.leAltSeries.text()
+        md.gtin = utils.xlate(self.leGtin.text())
         md.web_links = [utils.parse_url(self.leWebLink.item(i).text()) for i in range(self.leWebLink.count())]
         md.characters = set(utils.split(self.teCharacters.toPlainText(), "\n"))
         md.teams = set(utils.split(self.teTeams.toPlainText(), "\n"))

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -53,6 +53,7 @@ from comictaggerlib.ctsettings import ct_ns
 from comictaggerlib.exportwindow import ExportConflictOpts, ExportWindow
 from comictaggerlib.fileselectionlist import FileSelectionList
 from comictaggerlib.graphics import graphics_path
+from comictaggerlib.gtinvalidator import is_valid_gtin
 from comictaggerlib.issueidentifier import IssueIdentifier
 from comictaggerlib.logwindow import LogWindow
 from comictaggerlib.md import prepare_metadata
@@ -290,6 +291,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
         self.page_list_editor.firstFrontCoverChanged.connect(self.front_cover_changed)
         self.page_list_editor.listOrderChanged.connect(self.page_list_order_changed)
         self.tabWidget.currentChanged.connect(self.tab_changed)
+        self.leGtin.textChanged.connect(self.gtin_changed)
 
         self.page_list_editor.set_blur(self.config[0].General__blur)
 
@@ -844,13 +846,14 @@ class TaggerWindow(QtWidgets.QMainWindow):
         assign_text(self.leAltSeries, md.alternate_series)
         assign_text(self.leAltIssueNum, md.alternate_number)
         assign_text(self.leAltIssueCount, md.alternate_count)
-        assign_text(self.leGtin, md.gtin)
         self.leWebLink.clear()
         for u in md.web_links:
             self.add_weblink_item(u.url)
         assign_text(self.teCharacters, "\n".join(md.characters))
         assign_text(self.teTeams, "\n".join(md.teams))
         assign_text(self.teLocations, "\n".join(md.locations))
+
+        assign_text(self.leGtin, md.gtin)
 
         self.dsbCriticalRating.setValue(md.critical_rating or 0.0)
 
@@ -2242,6 +2245,15 @@ class TaggerWindow(QtWidgets.QMainWindow):
     def tab_changed(self, idx: int) -> None:
         if idx == 0:
             self.splitter_moved_event(0, 0)
+
+    def gtin_changed(self) -> None:
+        # GTIN changed, so we check if it's valid
+        gtin = self.leGtin.text().strip()
+        is_valid = is_valid_gtin(gtin) if gtin else True
+        if is_valid:
+            self.leGtin.setStyleSheet("")
+        else:
+            self.leGtin.setStyleSheet("background-color: salmon;")
 
     def check_latest_version_online(self) -> None:
         version_checker = VersionChecker()

--- a/comictaggerlib/ui/TemplateHelp.ui
+++ b/comictaggerlib/ui/TemplateHelp.ui
@@ -83,6 +83,7 @@ tr:nth-child(even) {
      &lt;tr&gt;&lt;td&gt;{alternate_series}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;
      &lt;tr&gt;&lt;td&gt;{alternate_number}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;
      &lt;tr&gt;&lt;td&gt;{alternate_count}&lt;/td&gt;&lt;td&gt;integer&lt;/td&gt;&lt;/tr&gt;
+     &lt;tr&gt;&lt;td&gt;{gtin}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;
      &lt;tr&gt;&lt;td&gt;{imprint}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;
      &lt;tr&gt;&lt;td&gt;{notes}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;
      &lt;tr&gt;&lt;td&gt;{web_link}&lt;/td&gt;&lt;td&gt;string&lt;/td&gt;&lt;/tr&gt;

--- a/comictaggerlib/ui/taggerwindow.ui
+++ b/comictaggerlib/ui/taggerwindow.ui
@@ -888,6 +888,23 @@ Source</string>
                         </property>
                        </widget>
                       </item>
+                      <item row="14" column="0">
+                       <widget class="QLabel" name="label_34">
+                        <property name="text">
+                         <string>GTIN</string>
+                        </property>
+                        <property name="buddy">
+                         <cstring>leGtin</cstring>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="14" column="1">
+                       <widget class="QLineEdit" name="leGtin">
+                        <property name="acceptDrops">
+                         <bool>false</bool>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                    </layout>

--- a/testing/comicvine.py
+++ b/testing/comicvine.py
@@ -213,6 +213,7 @@ cv_md = comicapi.genericmetadata.GenericMetadata(
     alternate_series=None,
     alternate_number=None,
     alternate_count=None,
+    gtin=None,
     imprint=None,
     notes=None,
     web_links=[comicapi.genericmetadata.parse_url(cv_issue_result["results"]["site_detail_url"])],


### PR DESCRIPTION
This is my first public contribution ever, so please bear with me.

I've added support for the GTIN tag to represent the EAN/ISBN, as specified in https://anansi-project.github.io/fr/docs/comicinfo/documentation#gtin

Related issue: #761 

No tests were added, but one had to be changed to include the new identifier.

The text field is at the bottom of the Details page. 
The reading of the GTIN is implementation-dependant, so I figured a large text box would be fitting since one could use it with multiple identifiers at once (isbn:xxxxxx,ean:yyyyy,bookid:zzzzz).