### PR TITLE
Fix open folder as a comic

### DIFF
--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -1093,7 +1093,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
         self.select_file(folder_mode=True)
 
     def select_folder_archive(self) -> None:
-        self.select_file(folder_mode=True, recursive=True)
+        self.select_file(folder_mode=True, recursive=False)
 
     def select_file(self, folder_mode: bool = False, recursive: bool = True) -> None:
         dialog = self.file_dialog(folder_mode=folder_mode)


### PR DESCRIPTION
Since version [1.6.0-beta.7](https://github.com/comictagger/comictagger/releases/tag/1.6.0-beta.8) opening a folder as a comic functionality was broken,
This PR fixes the issue.