### PR TITLE
cli+fix: Allow saving and reading 'tags' for CR type ComicInfo

### DIFF
--- a/comicapi/tags/comicrack.py
+++ b/comicapi/tags/comicrack.py
@@ -44,6 +44,7 @@ class ComicRack(Tag):
             "title",
             "volume",
             "genres",
+            "tags",
             "description",
             "notes",
             "alternate_series",
@@ -224,6 +225,7 @@ class ComicRack(Tag):
         assign("Title", md.title)
         assign("Volume", md.volume)
         assign("Genre", md.genres)
+        assign("Tags", md.tags)
         assign("Summary", md.description)
         assign("Notes", md.notes)
 
@@ -311,6 +313,7 @@ class ComicRack(Tag):
         md.title = utils.xlate(get("Title"))
         md.volume = utils.xlate_int(get("Volume"))
         md.genres = set(utils.split(get("Genre"), ","))
+        md.tags = set(utils.split(get("Tags"), ","))
         md.description = utils.xlate(get("Summary"))
         md.notes = utils.xlate(get("Notes"))
 


### PR DESCRIPTION
This commit adds 3 lines of code to the comicrack format so that CLI usage allows saving (and printing) "tags", which is supported by ComicInfo v2.1 (draft) according to the spec.

It does not add anything in the GUI.