### PR TITLE
Sequence first-run dialogs

### DIFF
--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -372,15 +372,21 @@ class TaggerWindow(QtWidgets.QMainWindow):
         QtCore.QCoreApplication.processEvents()
         self.resizeEvent(None)
 
-        if self.config[0].Dialog_Flags__show_disclaimer:
+        connection_type = QtCore.Qt.ConnectionType.SingleShotConnection
+
+        def show_welcome() -> None:
+            if not self.config[0].Dialog_Flags__show_disclaimer:
+                show_plugin_notice()
+                return
 
             def set_checked(checked: bool) -> None:
                 self.config[0].Dialog_Flags__show_disclaimer = not checked
 
-            OptionalMessageDialog.msg(
+            dialog = OptionalMessageDialog.msg(
                 self,
                 "Welcome!",
-                textwrap.dedent("""
+                textwrap.dedent(
+                    """
                 Thanks for trying ComicTagger!
 
                 Be aware that this is beta-level software, and consider it experimental.
@@ -403,10 +409,18 @@ class TaggerWindow(QtWidgets.QMainWindow):
 
                 [here]: https://github.com/comictagger/comictagger/wiki/Comic-and-Manga-Information-Sources
                 [Wiki page]: https://github.com/comictagger/comictagger/wiki/UserGuide#comic-vine
-                    """),
-            ).check_status.connect(set_checked)
+                    """
+                ),
+            )
+            dialog.check_status.connect(set_checked)
+            dialog.finished.connect(
+                lambda _result: QtCore.QTimer.singleShot(0, show_plugin_notice), type=connection_type
+            )
 
-        if self.config[0].Dialog_Flags__notify_plugin_changes:
+        def show_plugin_notice() -> None:
+            if not self.config[0].Dialog_Flags__notify_plugin_changes:
+                check_for_new_version()
+                return
 
             def set_checked(checked: bool) -> None:
                 self.config[0].Dialog_Flags__notify_plugin_changes = not checked
@@ -414,7 +428,8 @@ class TaggerWindow(QtWidgets.QMainWindow):
             self.dlg = OptionalMessageDialog.msg(
                 self,
                 "Plugins Have moved!",
-                textwrap.dedent(f"""
+                textwrap.dedent(
+                    f"""
                 Due to techinical issues the Metron is not supported anymore and the GCD plugin is no longer bundled in ComicTagger!
 
                 You will need to download the .zip or .whl from the GitHub release page to:
@@ -426,19 +441,28 @@ class TaggerWindow(QtWidgets.QMainWindow):
                 For more information on installing plugins see the wiki page:
 
                 https://github.com/comictagger/comictagger/wiki/Installing-plugins
-                """),
-            ).check_status.connect(set_checked)
-
-        try:
-            if self.config[0].General__check_for_new_version:
-                self.check_latest_version_online()
-        except Exception:
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            trace_back = "".join(traceback.format_tb(exc_traceback))
-            logger.exception("Failed to check for new version")
-            OptionalMessageDialog.critical(
-                self, "Failed to check for new version", "Failed to check for new version", trace_back
+                """
+                ),
             )
+            self.dlg.check_status.connect(set_checked)
+            self.dlg.finished.connect(
+                lambda _result: QtCore.QTimer.singleShot(0, check_for_new_version), type=connection_type
+            )
+
+        def check_for_new_version() -> None:
+            try:
+                if self.config[0].General__check_for_new_version:
+                    self.check_latest_version_online()
+            except Exception:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                trace_back = "".join(traceback.format_tb(exc_traceback))
+                logger.exception("Failed to check for new version")
+                OptionalMessageDialog.critical(
+                    self, "Failed to check for new version", "Failed to check for new version", trace_back
+                )
+
+        show_welcome()
+
         self.export_window = ExportWindow(self)
         self.export_window.export.connect(self._repackage_archive)
 

--- a/comictaggerlib/taggerwindow.py
+++ b/comictaggerlib/taggerwindow.py
@@ -385,8 +385,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
             dialog = OptionalMessageDialog.msg(
                 self,
                 "Welcome!",
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                 Thanks for trying ComicTagger!
 
                 Be aware that this is beta-level software, and consider it experimental.
@@ -409,8 +408,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
 
                 [here]: https://github.com/comictagger/comictagger/wiki/Comic-and-Manga-Information-Sources
                 [Wiki page]: https://github.com/comictagger/comictagger/wiki/UserGuide#comic-vine
-                    """
-                ),
+                    """),
             )
             dialog.check_status.connect(set_checked)
             dialog.finished.connect(
@@ -428,8 +426,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
             self.dlg = OptionalMessageDialog.msg(
                 self,
                 "Plugins Have moved!",
-                textwrap.dedent(
-                    f"""
+                textwrap.dedent(f"""
                 Due to techinical issues the Metron is not supported anymore and the GCD plugin is no longer bundled in ComicTagger!
 
                 You will need to download the .zip or .whl from the GitHub release page to:
@@ -441,8 +438,7 @@ class TaggerWindow(QtWidgets.QMainWindow):
                 For more information on installing plugins see the wiki page:
 
                 https://github.com/comictagger/comictagger/wiki/Installing-plugins
-                """
-                ),
+                """),
             )
             self.dlg.check_status.connect(set_checked)
             self.dlg.finished.connect(


### PR DESCRIPTION
Fixes #819

On first launch, ComicTagger opens the welcome and plugin dialogs without waiting for the first to close, then begins checking for updates. On Wayland, the resulting focus and stacking order can leave the dialogs overlapping and can intermittently make the visible dialog impossible to interact with.

This change keeps the existing dialog text and preference handling, but presents each enabled startup notice in order. Configurations with only one enabled notice, or with both notices disabled, retain their existing behaviour.

Testing
- pytest tests: 438 passed, 1 skipped, 53 expected failures, 0 unexpected.
- Formatting and lint checks passed: Black, Flake8, isort, Ruff, and git diff --check
- Manual comparison on NixOS/GNOME Wayland